### PR TITLE
Fix/#22 add memory

### DIFF
--- a/OurMemory_Server/src/main/java/com/kds/ourmemory/advice/CRestControllerAdvice.java
+++ b/OurMemory_Server/src/main/java/com/kds/ourmemory/advice/CRestControllerAdvice.java
@@ -21,6 +21,15 @@ import com.kds.ourmemory.controller.v1.ApiResult;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+/**
+ * REST API 예외처리 어드바이스 코드
+ * 
+ * 해당 코드로 캐치된 경우, 통신 자체는 성공한 것이기 때문에 상태코드 값을 200으로 하고
+ * 에러코드 값을 전달하여 프론트에서 분기하도록 한다.
+ * 
+ * @author idean
+ *
+ */
 @Slf4j
 @RestControllerAdvice
 @RequiredArgsConstructor
@@ -28,8 +37,6 @@ public class CRestControllerAdvice {
     
     private final MessageSource messageSource;
     
-    // 통신은 성공했기 때문에 스테이터스를 200으로 설정
-    // errorCode 값으로 에러를 분류하도록 한다.
     private ResponseEntity<ApiResult<?>> response(String errorCode, String errorMessage) {
         HttpHeaders headers = new HttpHeaders();
         headers.add("Content-Type", "application/json");

--- a/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/memory/MemoryController.java
+++ b/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/memory/MemoryController.java
@@ -2,7 +2,11 @@ package com.kds.ourmemory.controller.v1.memory;
 
 import static com.kds.ourmemory.controller.v1.ApiResult.ok;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -11,8 +15,10 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.kds.ourmemory.controller.v1.ApiResult;
 import com.kds.ourmemory.controller.v1.memory.dto.DeleteMemoryResponseDto;
+import com.kds.ourmemory.controller.v1.memory.dto.FindMemoryResponseDto;
 import com.kds.ourmemory.controller.v1.memory.dto.InsertMemoryRequestDto;
 import com.kds.ourmemory.controller.v1.memory.dto.InsertMemoryResponseDto;
+import com.kds.ourmemory.entity.memory.Memory;
 import com.kds.ourmemory.service.v1.memory.MemoryService;
 
 import io.swagger.annotations.Api;
@@ -28,10 +34,17 @@ public class MemoryController {
     
     private final MemoryService memoryService;
 
-    @ApiOperation(value="일정 추가", notes = "앱에서 전달받은 데이터로 일정 추가")
+    @ApiOperation(value="일정 추가", notes = "일정을 추가하고 일정-방-사용자 의 관계를 설정한다.")
     @PostMapping("/memory")
     public ApiResult<InsertMemoryResponseDto> addMemory(@RequestBody InsertMemoryRequestDto request) {
         return ok(memoryService.insert(request));
+    }
+    
+    @ApiOperation(value = "일정 조회", notes = "사용자가 생성했거나 참여중인 일정을 조회한다.")
+    @GetMapping("/memory/{snsId}")
+    public ApiResult<List<FindMemoryResponseDto>> findMemorys(@ApiParam(value = "snsId", required = true) @PathVariable String snsId) {
+        return ok(memoryService.findMemorys(snsId).stream().filter(Memory::isUsed).map(FindMemoryResponseDto::new)
+                .collect(Collectors.toList()));
     }
     
     @ApiOperation(value = "일정 삭제", notes = "일정 삭제, 사용자-일정-방 연결된 관계 삭제")

--- a/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/memory/dto/FindMemoryResponseDto.java
+++ b/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/memory/dto/FindMemoryResponseDto.java
@@ -1,0 +1,73 @@
+package com.kds.ourmemory.controller.v1.memory.dto;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.kds.ourmemory.controller.v1.user.dto.SignInResponseDto;
+import com.kds.ourmemory.entity.memory.Memory;
+import com.kds.ourmemory.entity.user.User;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Getter;
+
+@Getter
+public class FindMemoryResponseDto {
+    @ApiModelProperty(value = "일정 번호", example = "5")
+    private Long id;
+    
+    @ApiModelProperty(value = "일정 작성자 번호", example = "64")
+    private Long writer;
+    
+    @ApiModelProperty(value = "일정 제목", example = "회의 일정")
+    private String name;
+    
+    @ApiModelProperty(value = "일정 내용", example = "주간 회의")
+    private String contents;
+    
+    @ApiModelProperty(value = "장소", example = "신도림역 1번 출구")
+    private String place;
+    
+    @ApiModelProperty(value = "시작 시간", notes = "yyyy-MM-dd HH:mm")
+    private Date startDate;
+    
+    @ApiModelProperty(value = "종료 시간", notes = "yyyy-MM-dd HH:mm")
+    private Date endDate;
+    
+    @ApiModelProperty(value = "배경색", example = "#FFFFFF")
+    private String bgColor;
+    
+    @ApiModelProperty(value = "첫 번째 알림 시간", notes = "yyyy-MM-dd HH:mm")
+    private Date firstAlarm;
+    
+    @ApiModelProperty(value = "두 번째 알림 시간", notes = "yyyy-MM-dd HH:mm")
+    private Date secondAlarm;
+    
+    @ApiModelProperty(value = "일정 등록날짜", notes = "yyyyMMdd")
+    private Date regDate;
+    
+    @ApiModelProperty(value = "일정 수정날짜", notes = "yyyyMMdd")
+    private Date modDate;
+    
+    @ApiModelProperty(value = "일정 참여자", notes = "일정을 생성한 사람도 참여자에 포함되어 전달됨.", example = "[{참여자1}, {참여자2}]")
+    private List<SignInResponseDto> members = new ArrayList<>();
+    
+    public FindMemoryResponseDto(Memory memory) {
+        id = memory.getId();
+        writer = memory.getWriter().getId();
+        name = memory.getName();
+        contents = memory.getContents();
+        place = memory.getPlace();
+        startDate = memory.getStartDate();
+        endDate = memory.getEndDate();
+        bgColor = memory.getBgColor();
+        firstAlarm = memory.getFirstAlarm();
+        secondAlarm = memory.getSecondAlarm();
+        regDate = memory.getRegDate();
+        modDate = memory.getModDate();
+        
+        members = memory.getUsers().stream().filter(User::isUsed).map(SignInResponseDto::new)
+                .collect(Collectors.toList());
+    }
+}

--- a/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/memory/dto/InsertMemoryRequestDto.java
+++ b/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/memory/dto/InsertMemoryRequestDto.java
@@ -33,19 +33,19 @@ public class InsertMemoryRequestDto {
     private String place;
 
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
-    @ApiModelProperty(value = "시작 시간", required = true, example = "2021-03-15 22:11")
+    @ApiModelProperty(value = "시작 시간", required = true, notes = "yyyy-MM-dd HH:mm")
     private Date startDate;
 
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
-    @ApiModelProperty(value = "종료 시간", required = true, example = "2021-03-15 23:11")
+    @ApiModelProperty(value = "종료 시간", required = true, notes = "yyyy-MM-dd HH:mm")
     private Date endDate;
 
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
-    @ApiModelProperty(value = "첫 번째 알림 시간", required = false, example = "2021-03-14 22:00")
+    @ApiModelProperty(value = "첫 번째 알림 시간", required = false, notes = "yyyy-MM-dd HH:mm")
     private Date firstAlarm;
 
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
-    @ApiModelProperty(value = "두 번째 알림 시간", required = false, example = "2021-03-15 21:00")
+    @ApiModelProperty(value = "두 번째 알림 시간", required = false, notes = "yyyy-MM-dd HH:mm")
     private Date secondAlarm;
 
     @ApiModelProperty(value = "배경색", required = true, example = "#FFFFFF")

--- a/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/memory/dto/InsertMemoryRequestDto.java
+++ b/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/memory/dto/InsertMemoryRequestDto.java
@@ -16,11 +16,14 @@ import lombok.NoArgsConstructor;
 public class InsertMemoryRequestDto {
     @ApiModelProperty(value = "일정 작성자 snsId", required = true)
     private String snsId;
+    
+    @ApiModelProperty(value = "방 번호", required = false, notes = "일정을 등록할 방. 참여자가 있는데 방 번호가 없는 경우, 새로 생성한다.")
+    private Long roomId;
 
     @ApiModelProperty(value = "일정 이름", required = true, example = "회의 일정")
     private String name;
     
-    @ApiModelProperty(value = "일정 참여자", required = true, example = "[2,4,5]")
+    @ApiModelProperty(value = "일정 참여자", required = false, notes = "참여자가 방에 포함된 사람과 다르거나 많을 경우, 방을 새로 생성한다.", example = "[2,4,5]")
     private List<Long> members;
 
     @ApiModelProperty(value = "일정 내용", required = false)
@@ -48,6 +51,6 @@ public class InsertMemoryRequestDto {
     @ApiModelProperty(value = "배경색", required = true, example = "#FFFFFF")
     private String bgColor;
 
-    @ApiModelProperty(value = "공유할 방 목록", required = false)
-    private List<Long> roomIds;
+    @ApiModelProperty(value = "일정을 공유할 방 목록", required = false, notes = "공유할 방의 허락을 받은 뒤 일정을 공유시킨다.")
+    private List<Long> shareRooms;
 }

--- a/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/memory/dto/InsertMemoryRequestDto.java
+++ b/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/memory/dto/InsertMemoryRequestDto.java
@@ -23,7 +23,7 @@ public class InsertMemoryRequestDto {
     @ApiModelProperty(value = "일정 이름", required = true, example = "회의 일정")
     private String name;
     
-    @ApiModelProperty(value = "일정 참여자", required = false, notes = "참여자가 방에 포함된 사람과 다르거나 많을 경우, 방을 새로 생성한다.", example = "[2,4,5]")
+    @ApiModelProperty(value = "일정 참여자 번호", required = false, notes = "참여자가 방에 포함된 사람과 다르거나 많을 경우, 방을 새로 생성한다.", example = "[2,4,5]")
     private List<Long> members;
 
     @ApiModelProperty(value = "일정 내용", required = false)

--- a/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/memory/dto/InsertMemoryResponseDto.java
+++ b/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/memory/dto/InsertMemoryResponseDto.java
@@ -10,6 +10,9 @@ public class InsertMemoryResponseDto {
     @ApiModelProperty(value = "일정 번호", example = "3")
     private Long id;
     
+    @ApiModelProperty(value = "방 번호", notes = "일정이 포함된 기준 방의 번호, 방에 포함되지 않는 경우 null 리턴됨.", example = "65")
+    private Long roomId;
+    
     @ApiModelProperty(value="일정 추가한 날짜", example = "20210315")
     private String addDate;
 }

--- a/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/room/dto/FindRoomResponseDto.java
+++ b/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/room/dto/FindRoomResponseDto.java
@@ -9,16 +9,14 @@ import com.kds.ourmemory.entity.room.Room;
 import com.kds.ourmemory.entity.user.User;
 
 import io.swagger.annotations.ApiModelProperty;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
 public class FindRoomResponseDto {
     @ApiModelProperty(value = "방 번호", example = "5")
     private Long id;
 
-    @ApiModelProperty(value = "방 소유자", example = "17")
+    @ApiModelProperty(value = "방 소유자 번호", example = "17")
     private Long owner;
 
     @ApiModelProperty(value = "방 이름", example = "가족방")
@@ -31,7 +29,7 @@ public class FindRoomResponseDto {
     private boolean opened;
 
     @ApiModelProperty(value = "방 참여자", example = "[{사용자}, {사용자2}]")
-    private List<SignInResponseDto> member;
+    private List<SignInResponseDto> members;
 
     public FindRoomResponseDto(Room room) {
         id = room.getId();
@@ -39,7 +37,7 @@ public class FindRoomResponseDto {
         name = room.getName();
         regTime = new SimpleDateFormat("yyyyMMdd").format(room.getRegDate());
         opened = room.isOpened();
-        member = room.getUsers().stream().filter(User::isUsed).map(SignInResponseDto::new)
+        members = room.getUsers().stream().filter(User::isUsed).map(SignInResponseDto::new)
                 .collect(Collectors.toList());
     }
 }

--- a/OurMemory_Server/src/main/java/com/kds/ourmemory/entity/memory/Memory.java
+++ b/OurMemory_Server/src/main/java/com/kds/ourmemory/entity/memory/Memory.java
@@ -17,6 +17,8 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToMany;
 import javax.persistence.ManyToOne;
 
+import org.hibernate.annotations.DynamicUpdate;
+
 import com.kds.ourmemory.entity.room.Room;
 import com.kds.ourmemory.entity.user.User;
 
@@ -25,6 +27,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@DynamicUpdate
 @Entity(name = "memorys")
 @Builder
 @Getter

--- a/OurMemory_Server/src/main/java/com/kds/ourmemory/service/v1/memory/MemoryService.java
+++ b/OurMemory_Server/src/main/java/com/kds/ourmemory/service/v1/memory/MemoryService.java
@@ -3,12 +3,16 @@ package com.kds.ourmemory.service.v1.memory;
 import static com.kds.ourmemory.util.DateUtil.currentDate;
 import static com.kds.ourmemory.util.DateUtil.currentTime;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import javax.transaction.Transactional;
 
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
 
 import com.kds.ourmemory.advice.exception.CMemoryException;
@@ -16,6 +20,8 @@ import com.kds.ourmemory.advice.exception.CRoomException;
 import com.kds.ourmemory.controller.v1.memory.dto.DeleteMemoryResponseDto;
 import com.kds.ourmemory.controller.v1.memory.dto.InsertMemoryRequestDto;
 import com.kds.ourmemory.controller.v1.memory.dto.InsertMemoryResponseDto;
+import com.kds.ourmemory.controller.v1.room.dto.InsertRoomRequestDto;
+import com.kds.ourmemory.controller.v1.room.dto.InsertRoomResponseDto;
 import com.kds.ourmemory.entity.memory.Memory;
 import com.kds.ourmemory.entity.room.Room;
 import com.kds.ourmemory.entity.user.User;
@@ -23,12 +29,15 @@ import com.kds.ourmemory.repository.memory.MemoryRepository;
 import com.kds.ourmemory.repository.room.RoomRepository;
 import com.kds.ourmemory.repository.user.UserRepository;
 import com.kds.ourmemory.service.v1.firebase.FirebaseCloudMessageService;
+import com.kds.ourmemory.service.v1.room.RoomService;
 
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @Service
 public class MemoryService {
+    private final RoomService roomService;
+    
     private final UserRepository userRepo;
     private final MemoryRepository memoryRepo;
     private final RoomRepository roomRepo;
@@ -60,9 +69,10 @@ public class MemoryService {
                         .map(writer -> writer.addMemory(memory))
                         .map(memory::addUser)
                         .orElseThrow(() -> new CMemoryException("Insert failed Relational Data to users_memorys."));
-                    addMemberToMemory(memory, request.getMembers());
                     
-                    addRoomToMemory(memory, request.getRoomIds());
+                    addMemberToMemory(memory, request.getMembers());
+                    addRoomToMemory(memory, request.getShareRooms());
+                    relationMainRoom(memory, request);
                     return memory;
                 })
                 .map(memory -> new InsertMemoryResponseDto(memory.getId(), currentDate()))
@@ -84,12 +94,12 @@ public class MemoryService {
                  })
                  .orElseThrow(() -> new CRoomException("memberId is Not Registered DB. id: " + id));
              }));
-    
+        
         return memory;
     }
     
     @Transactional
-    public Memory addMemberToMemory(Memory memory, List<Long> members)throws CMemoryException {
+    public void addMemberToMemory(Memory memory, List<Long> members)throws CMemoryException {
         Optional.ofNullable(members).map(List::stream)
             .ifPresent(stream -> stream.forEach(id -> {
                 findUserById(id).filter(Objects::nonNull)
@@ -103,8 +113,41 @@ public class MemoryService {
                  })
                  .orElseThrow(() -> new CRoomException("memberId is Not Registered DB. id: " + id));
              }));
+    }
     
-        return memory;
+    /**
+     * 일정이 포함될 메인 방 설정
+     * 
+     * 1. 참여자와 방이 매치되지 않는 경우, 방을 새로 생성 후 일정-방 연결
+     * 2. 매치될 경우, 해당 방-일정 연결
+     * 
+     * @param memory
+     * @param request
+     */
+    private void relationMainRoom(Memory memory, InsertMemoryRequestDto request) {
+        Room mainRoom = Optional.ofNullable(request.getRoomId())
+            .map(id -> roomRepo.findById(id).get())
+            .filter(room -> {
+                List<Long> memoryMembers = memory.getUsers().stream().map(User::getId).collect(Collectors.toList());
+                
+                return room.getUsers().stream()
+                    .map(User::getId).collect(Collectors.toList())
+                    .containsAll(memoryMembers);
+            })
+            .orElseGet(() -> {
+                return Optional.ofNullable(memory.getUsers())
+                    .map(users -> {
+                        String name = StringUtils.join(users.stream().map(User::getId).collect(Collectors.toList()), ", ");
+                        Long owner = memory.getWriter().getId();
+                        InsertRoomRequestDto insertRoomRequestDto = new InsertRoomRequestDto(name, owner, false, request.getMembers());
+                        InsertRoomResponseDto insertRoomResponseDto = roomService.insert(insertRoomRequestDto);
+                        return roomRepo.findById(insertRoomResponseDto.getId()).get();
+                    })
+                    .orElse(null);
+            });
+        
+        Optional.ofNullable(mainRoom)
+            .map(room -> addRoomToMemory(memory, Arrays.asList(new Long[] {room.getId()})));
     }
     
     @Transactional

--- a/OurMemory_Server/src/main/java/com/kds/ourmemory/service/v1/memory/MemoryService.java
+++ b/OurMemory_Server/src/main/java/com/kds/ourmemory/service/v1/memory/MemoryService.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Service;
 
 import com.kds.ourmemory.advice.exception.CMemoryException;
 import com.kds.ourmemory.advice.exception.CRoomException;
+import com.kds.ourmemory.advice.exception.CUserNotFoundException;
 import com.kds.ourmemory.controller.v1.memory.dto.DeleteMemoryResponseDto;
 import com.kds.ourmemory.controller.v1.memory.dto.InsertMemoryRequestDto;
 import com.kds.ourmemory.controller.v1.memory.dto.InsertMemoryResponseDto;
@@ -136,7 +137,7 @@ public class MemoryService {
             })
             .orElseGet(() -> Optional.ofNullable(memory.getUsers())
                                 .map(users -> {
-                                    String name = StringUtils.join(users.stream().map(User::getId).collect(Collectors.toList()), ", ");
+                                    String name = StringUtils.join(users.stream().map(User::getName).collect(Collectors.toList()), ", ");
                                     Long owner = memory.getWriter().getId();
                                     InsertRoomRequestDto insertRoomRequestDto = new InsertRoomRequestDto(name, owner, false, request.getMembers());
                                     InsertRoomResponseDto insertRoomResponseDto = roomService.insert(insertRoomRequestDto);
@@ -146,6 +147,11 @@ public class MemoryService {
         
         Optional.ofNullable(mainRoom)
             .map(room -> addRoomToMemory(memory, Arrays.asList(room.getId())));
+    }
+    
+    public List<Memory> findMemorys(String snsId) throws CUserNotFoundException {
+        return findUserBySnsId(snsId).map(User::getMemorys)
+                .orElseThrow(() -> new CUserNotFoundException("Not Found User From snsId: " + snsId));
     }
     
     @Transactional

--- a/OurMemory_Server/src/test/java/com/kds/ourmemory/service/v1/memory/MemoryServiceTest.java
+++ b/OurMemory_Server/src/test/java/com/kds/ourmemory/service/v1/memory/MemoryServiceTest.java
@@ -33,8 +33,33 @@ import lombok.extern.slf4j.Slf4j;
 class MemoryServiceTest {
     
     @Autowired private MemoryService memoryService;
-    private InsertMemoryRequestDto insertMemoryRequestDto;
-    private InsertMemoryResponseDto insertMemoryResponseDto;
+    /**
+     * 일정을 등록할 방이 있는 경우
+     * 참여자가 있는 경우 
+     */
+    private InsertMemoryRequestDto insertRequest_방O_참여자O;
+    private InsertMemoryResponseDto insertResponse_방O_참여자O;
+    
+    /**
+     * 일정을 등록할 방이 있는 경우
+     * 참여자가 없는 경우
+     */
+    private InsertMemoryRequestDto insertRequest_방O_참여자X;
+    private InsertMemoryResponseDto insertResponse_방O_참여자X;
+    
+    /**
+     * 일정을 등록할 방이 없는 경우
+     * 참여자 있는 경우
+     */
+    private InsertMemoryRequestDto insertRequest_방X_참여자O;
+    private InsertMemoryResponseDto insertResponse_방X_참여자O;
+    
+    /**
+     * 일정을 등록할 방이 없는 경우
+     * 참여자 없는 경우
+     */
+    private InsertMemoryRequestDto insertRequest_방X_참여자X;
+    private InsertMemoryResponseDto insertResponse_방X_참여자X;
     
     @BeforeAll
     void setUp() throws ParseException {
@@ -44,8 +69,9 @@ class MemoryServiceTest {
         List<Long> roomIds = new ArrayList<>();
         roomIds.add(64L);
         
-        insertMemoryRequestDto = new InsertMemoryRequestDto(
-                "19930724", 
+        insertRequest_방O_참여자O = new InsertMemoryRequestDto(
+                "19930724",
+                64L,
                 "테스트 일정",
                 members,
                 "테스트 내용", 
@@ -56,23 +82,126 @@ class MemoryServiceTest {
                 null,       // 두 번째 알림
                 "#FFFFFF",  // 배경색
                 roomIds     // 공유할 방
-                );  
+                );
+        
+        
+        insertRequest_방O_참여자X = new InsertMemoryRequestDto(
+                "19930724",
+                64L,
+                "테스트 일정",
+                null,
+                "테스트 내용", 
+                "테스트 장소", 
+                new SimpleDateFormat("yyyy-MM-dd HH:ss").parse("2021-03-26 17:00"), // 시작 시간 
+                new SimpleDateFormat("yyyy-MM-dd HH:ss").parse("2021-03-26 18:00"), // 종료 시간
+                new SimpleDateFormat("yyyy-MM-dd HH:ss").parse("2021-03-25 17:00"), // 첫 번째 알림
+                null,       // 두 번째 알림
+                "#FFFFFF",  // 배경색
+                roomIds     // 공유할 방
+                );
+        
+        insertRequest_방X_참여자O = new InsertMemoryRequestDto(
+                "19930724",
+                null,
+                "테스트 일정",
+                members,
+                "테스트 내용", 
+                "테스트 장소", 
+                new SimpleDateFormat("yyyy-MM-dd HH:ss").parse("2021-03-26 17:00"), // 시작 시간 
+                new SimpleDateFormat("yyyy-MM-dd HH:ss").parse("2021-03-26 18:00"), // 종료 시간
+                new SimpleDateFormat("yyyy-MM-dd HH:ss").parse("2021-03-25 17:00"), // 첫 번째 알림
+                null,       // 두 번째 알림
+                "#FFFFFF",  // 배경색
+                roomIds     // 공유할 방
+                );
+        
+        insertRequest_방X_참여자X = new InsertMemoryRequestDto(
+                "19930724",
+                null,
+                "테스트 일정",
+                null,
+                "테스트 내용", 
+                "테스트 장소", 
+                new SimpleDateFormat("yyyy-MM-dd HH:ss").parse("2021-03-26 17:00"), // 시작 시간 
+                new SimpleDateFormat("yyyy-MM-dd HH:ss").parse("2021-03-26 18:00"), // 종료 시간
+                new SimpleDateFormat("yyyy-MM-dd HH:ss").parse("2021-03-25 17:00"), // 첫 번째 알림
+                null,       // 두 번째 알림
+                "#FFFFFF",  // 배경색
+                roomIds     // 공유할 방
+                );
     }
     
     @Test
     @Order(1)
-    void 일정_생성() throws CMemoryException {
-        insertMemoryResponseDto = memoryService.insert(insertMemoryRequestDto);
-        assertThat(insertMemoryResponseDto).isNotNull();
-        assertThat(insertMemoryResponseDto.getAddDate()).isEqualTo(currentDate());
+    void 방O_참여자O_일정_생성() throws CMemoryException {
+        insertResponse_방O_참여자O = memoryService.insert(insertRequest_방O_참여자O);
+        assertThat(insertResponse_방O_참여자O).isNotNull();
+        assertThat(insertResponse_방O_참여자O.getAddDate()).isEqualTo(currentDate());
         
-        log.info("CreateDate: {} memoryId: {}", insertMemoryResponseDto.getAddDate(), insertMemoryResponseDto.getId());
+        log.info("CreateDate: {} memoryId: {}", insertResponse_방O_참여자O.getAddDate(), insertResponse_방O_참여자O.getId());
     }
     
     @Test
     @Order(2)
-    void 일정_삭제() throws CRoomException {
-        DeleteMemoryResponseDto deleteMemoryResponseDto = memoryService.delete(insertMemoryResponseDto.getId());
+    void 방O_참여자O_일정_삭제() throws CRoomException {
+        DeleteMemoryResponseDto deleteMemoryResponseDto = memoryService.delete(insertResponse_방O_참여자O.getId());
+        
+        assertThat(deleteMemoryResponseDto).isNotNull();
+        assertThat(deleteMemoryResponseDto.getDeleteDate()).isEqualTo(currentDate());
+    }
+    
+    @Test
+    @Order(3)
+    void 방O_참여자X_일정_생성() throws CMemoryException {
+        insertResponse_방O_참여자X = memoryService.insert(insertRequest_방O_참여자X);
+        assertThat(insertResponse_방O_참여자X).isNotNull();
+        assertThat(insertResponse_방O_참여자X.getAddDate()).isEqualTo(currentDate());
+        
+        log.info("CreateDate: {} memoryId: {}", insertResponse_방O_참여자X.getAddDate(), insertResponse_방O_참여자X.getId());
+    }
+    
+    @Test
+    @Order(4)
+    void 방O_참여자X_일정_삭제() throws CRoomException {
+        DeleteMemoryResponseDto deleteMemoryResponseDto = memoryService.delete(insertResponse_방O_참여자X.getId());
+        
+        assertThat(deleteMemoryResponseDto).isNotNull();
+        assertThat(deleteMemoryResponseDto.getDeleteDate()).isEqualTo(currentDate());
+    }
+    
+    @Test
+    @Order(5)
+    void 방X_참여자O_일정_생성() throws CMemoryException {
+        insertResponse_방X_참여자O = memoryService.insert(insertRequest_방X_참여자O);
+        assertThat(insertResponse_방X_참여자O).isNotNull();
+        assertThat(insertResponse_방X_참여자O.getAddDate()).isEqualTo(currentDate());
+        
+        log.info("CreateDate: {} memoryId: {}", insertResponse_방O_참여자O.getAddDate(), insertResponse_방X_참여자O.getId());
+    }
+    
+    @Test
+    @Order(6)
+    void 방X_참여자O_일정_삭제() throws CRoomException {
+        DeleteMemoryResponseDto deleteMemoryResponseDto = memoryService.delete(insertResponse_방X_참여자O.getId());
+        
+        assertThat(deleteMemoryResponseDto).isNotNull();
+        assertThat(deleteMemoryResponseDto.getDeleteDate()).isEqualTo(currentDate());
+    }
+    
+    @Test
+    @Order(7)
+    void 방X_참여자X_일정_생성() throws CMemoryException {
+        insertResponse_방X_참여자X = memoryService.insert(insertRequest_방X_참여자X);
+        assertThat(insertResponse_방X_참여자X).isNotNull();
+        assertThat(insertResponse_방X_참여자X.getAddDate()).isEqualTo(currentDate());
+        
+        log.info("CreateDate: {} memoryId: {}", insertResponse_방O_참여자O.getAddDate(), insertResponse_방X_참여자X.getId());
+    }
+    
+    @Test
+    @Order(8)
+    void 방X_참여자X_일정_삭제() throws CRoomException {
+        DeleteMemoryResponseDto deleteMemoryResponseDto = memoryService.delete(insertResponse_방X_참여자X.getId());
         
         assertThat(deleteMemoryResponseDto).isNotNull();
         assertThat(deleteMemoryResponseDto.getDeleteDate()).isEqualTo(currentDate());

--- a/OurMemory_Server/src/test/java/com/kds/ourmemory/service/v1/memory/MemoryServiceTest.java
+++ b/OurMemory_Server/src/test/java/com/kds/ourmemory/service/v1/memory/MemoryServiceTest.java
@@ -36,9 +36,22 @@ import lombok.extern.slf4j.Slf4j;
 class MemoryServiceTest {
     
     @Autowired private MemoryService memoryService;
+    
     /**
-     * 일정을 등록할 방이 있는 경우
-     * 참여자가 있는 경우 
+     * _____________________________________
+     * |참여중인 방|        참여자      |방 생성여부|
+     * |=====================================|
+     * |    O   |0 <= 참여자 <= 방 인원|   X    |
+     * |    O   |0 < 참여자 != 방 인원 |   O    |
+     * |    X   |0 < 참여자 <= 방 인원 |   O    |
+     * |    X   |0 <= 참여자 <= 방 인원|   O    |
+     * |    X   |0 == 참여자         |   X    |
+     * ㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡ
+     */
+    
+    
+    /**
+     * 참여증인 방 O | 참여자 O | (방에)포함O
      */
     private InsertMemoryRequestDto insertRequest_방O_참여자O;
     private InsertMemoryResponseDto insertResponse_방O_참여자O;

--- a/OurMemory_Server/src/test/java/com/kds/ourmemory/service/v1/memory/MemoryServiceTest.java
+++ b/OurMemory_Server/src/test/java/com/kds/ourmemory/service/v1/memory/MemoryServiceTest.java
@@ -8,6 +8,8 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.transaction.Transactional;
+
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
@@ -22,6 +24,7 @@ import com.kds.ourmemory.advice.exception.CRoomException;
 import com.kds.ourmemory.controller.v1.memory.dto.DeleteMemoryResponseDto;
 import com.kds.ourmemory.controller.v1.memory.dto.InsertMemoryRequestDto;
 import com.kds.ourmemory.controller.v1.memory.dto.InsertMemoryResponseDto;
+import com.kds.ourmemory.entity.memory.Memory;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -138,11 +141,23 @@ class MemoryServiceTest {
         assertThat(insertResponse_방O_참여자O).isNotNull();
         assertThat(insertResponse_방O_참여자O.getAddDate()).isEqualTo(currentDate());
         
-        log.info("CreateDate: {} memoryId: {}", insertResponse_방O_참여자O.getAddDate(), insertResponse_방O_참여자O.getId());
+        log.info("[방O_참여자O] CreateDate: {} memoryId: {}", insertResponse_방O_참여자O.getAddDate(), insertResponse_방O_참여자O.getId());
     }
     
     @Test
     @Order(2)
+    @Transactional
+    void 방O_참여자O_일정_조회() {
+        List<Memory> responseList = memoryService.findMemorys(insertRequest_방O_참여자O.getSnsId());
+        assertThat(responseList).isNotNull();
+        
+        log.info("[방O_참여자O_일정_조회]");
+        responseList.stream().forEach(memory -> log.info("id: {}, name: {}", memory.getId(), memory.getName()));
+        log.info("====================================================================================");
+    }
+    
+    @Test
+    @Order(3)
     void 방O_참여자O_일정_삭제() throws CRoomException {
         DeleteMemoryResponseDto deleteMemoryResponseDto = memoryService.delete(insertResponse_방O_참여자O.getId());
         
@@ -151,17 +166,29 @@ class MemoryServiceTest {
     }
     
     @Test
-    @Order(3)
+    @Order(4)
     void 방O_참여자X_일정_생성() throws CMemoryException {
         insertResponse_방O_참여자X = memoryService.insert(insertRequest_방O_참여자X);
         assertThat(insertResponse_방O_참여자X).isNotNull();
         assertThat(insertResponse_방O_참여자X.getAddDate()).isEqualTo(currentDate());
         
-        log.info("CreateDate: {} memoryId: {}", insertResponse_방O_참여자X.getAddDate(), insertResponse_방O_참여자X.getId());
+        log.info("[방O_참여자X_일정_생성] CreateDate: {} memoryId: {}", insertResponse_방O_참여자X.getAddDate(), insertResponse_방O_참여자X.getId());
     }
     
     @Test
-    @Order(4)
+    @Order(5)
+    @Transactional
+    void 방O_참여자X_일정_조회() {
+        List<Memory> responseList = memoryService.findMemorys(insertRequest_방O_참여자X.getSnsId());
+        assertThat(responseList).isNotNull();
+        
+        log.info("[방O_참여자X_일정_조회]");
+        responseList.stream().forEach(memory -> log.info("id: {}, name: {}", memory.getId(), memory.getName()));
+        log.info("====================================================================================");
+    }
+    
+    @Test
+    @Order(6)
     void 방O_참여자X_일정_삭제() throws CRoomException {
         DeleteMemoryResponseDto deleteMemoryResponseDto = memoryService.delete(insertResponse_방O_참여자X.getId());
         
@@ -170,17 +197,29 @@ class MemoryServiceTest {
     }
     
     @Test
-    @Order(5)
+    @Order(7)
     void 방X_참여자O_일정_생성() throws CMemoryException {
         insertResponse_방X_참여자O = memoryService.insert(insertRequest_방X_참여자O);
         assertThat(insertResponse_방X_참여자O).isNotNull();
         assertThat(insertResponse_방X_참여자O.getAddDate()).isEqualTo(currentDate());
         
-        log.info("CreateDate: {} memoryId: {}", insertResponse_방O_참여자O.getAddDate(), insertResponse_방X_참여자O.getId());
+        log.info("[방X_참여자O_일정_생성] CreateDate: {} memoryId: {}", insertResponse_방O_참여자O.getAddDate(), insertResponse_방X_참여자O.getId());
     }
     
     @Test
-    @Order(6)
+    @Order(8)
+    @Transactional
+    void 방X_참여자O_일정_조회() {
+        List<Memory> responseList = memoryService.findMemorys(insertRequest_방X_참여자O.getSnsId());
+        assertThat(responseList).isNotNull();
+        
+        log.info("[방X_참여자O_일정_조회]");
+        responseList.stream().forEach(memory -> log.info("id: {}, name: {}", memory.getId(), memory.getName()));
+        log.info("====================================================================================");
+    }
+    
+    @Test
+    @Order(9)
     void 방X_참여자O_일정_삭제() throws CRoomException {
         DeleteMemoryResponseDto deleteMemoryResponseDto = memoryService.delete(insertResponse_방X_참여자O.getId());
         
@@ -189,17 +228,29 @@ class MemoryServiceTest {
     }
     
     @Test
-    @Order(7)
+    @Order(10)
     void 방X_참여자X_일정_생성() throws CMemoryException {
         insertResponse_방X_참여자X = memoryService.insert(insertRequest_방X_참여자X);
         assertThat(insertResponse_방X_참여자X).isNotNull();
         assertThat(insertResponse_방X_참여자X.getAddDate()).isEqualTo(currentDate());
         
-        log.info("CreateDate: {} memoryId: {}", insertResponse_방O_참여자O.getAddDate(), insertResponse_방X_참여자X.getId());
+        log.info("[방X_참여자X_일정_생성] CreateDate: {} memoryId: {}", insertResponse_방O_참여자O.getAddDate(), insertResponse_방X_참여자X.getId());
     }
     
     @Test
-    @Order(8)
+    @Order(11)
+    @Transactional
+    void 방X_참여자X_일정_조회() {
+        List<Memory> responseList = memoryService.findMemorys(insertRequest_방X_참여자X.getSnsId());
+        assertThat(responseList).isNotNull();
+        
+        log.info("[방X_참여자X_일정_조회]");
+        responseList.stream().forEach(memory -> log.info("id: {}, name: {}", memory.getId(), memory.getName()));
+        log.info("====================================================================================");
+    }
+    
+    @Test
+    @Order(12)
     void 방X_참여자X_일정_삭제() throws CRoomException {
         DeleteMemoryResponseDto deleteMemoryResponseDto = memoryService.delete(insertResponse_방X_참여자X.getId());
         

--- a/OurMemory_Server/src/test/java/com/kds/ourmemory/service/v1/room/RoomServiceTest.java
+++ b/OurMemory_Server/src/test/java/com/kds/ourmemory/service/v1/room/RoomServiceTest.java
@@ -7,6 +7,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import javax.transaction.Transactional;
+
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
@@ -57,6 +59,7 @@ class RoomServiceTest {
     
     @Test
     @Order(2)
+    @Transactional
     void 방_목록_조회() throws CUserNotFoundException {
         List<Room> responseList = Optional.ofNullable(userService.findUser(insertRoomRequestDto.getOwner()))
             .map(user -> roomService.findRooms(user.getSnsId()))
@@ -64,7 +67,9 @@ class RoomServiceTest {
         
         assertThat(responseList).isNotNull();
         
-        log.info("responseList : {}", responseList);
+        log.info("[방_목록_조회]");
+        responseList.stream().forEach(room -> log.info("id: {}, name: {}", room.getId(), room.getName()));
+        log.info("====================================================================================");
     }
     
     @Test

--- a/OurMemory_Server/src/test/java/com/kds/ourmemory/util/DateUtilTest.java
+++ b/OurMemory_Server/src/test/java/com/kds/ourmemory/util/DateUtilTest.java
@@ -1,0 +1,25 @@
+package com.kds.ourmemory.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+class DateUtilTest {
+    
+    @Test
+    void 시간_계산() {
+        log.info(DateUtil.currentTime().toString());
+    }
+    
+    @Test
+    void 날짜_계산() {
+        String currentDate = DateUtil.currentDate();
+        assertThat(currentDate).isEqualTo("20210323");
+        
+        log.info(currentDate);
+    }
+
+}


### PR DESCRIPTION
## #22 

## PR 설명
- 일정 추가 기능 수정

## 변경된 내용
- 일정 추가 시, 참여중인 방/참여자 여부에 따라 방과 일정을 다르게 연결하도록 수정
- 개인 일정이 아닌 경우, 필요에 따라 일정을 포함시킬 방을 새로 생성함.

|참여중인 방|참여자|방 생성 여부|
|---|---|---|
|O|0 < 참여자 <= 방 인원|X|
|O|0 < 참여자 != 방 인원|O|
|O|0 == 참여자|X|
|X|0 < 참여자|O|
|X|0 == 참여자|X|


## 추가적인 정보
- 일정 추가 시, 공유할 방은 방을 새로 생성하는데 관련이 없기 때문에 표에 추가하지 않음.