### PR TITLE
Fix/#71 mod memory api

### DIFF
--- a/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/firebase/dto/FcmDto.java
+++ b/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/firebase/dto/FcmDto.java
@@ -3,10 +3,7 @@ package com.kds.ourmemory.controller.v1.firebase.dto;
 import com.kds.ourmemory.entity.user.DeviceOs;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class FcmDto {
@@ -39,6 +36,7 @@ public class FcmDto {
         private String dataString;
 
         // constructor for required field only
+        @Builder
         public Request(String token, DeviceOs deviceOs, String title, String body) {
             this.token = token;
             this.deviceOs = deviceOs;

--- a/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/friend/FriendController.java
+++ b/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/friend/FriendController.java
@@ -61,8 +61,11 @@ public class FriendController {
     }
 
     @ApiOperation(value = "친구 삭제", notes = "친구를 삭제한다. 내 쪽에서만 친구 삭제 처리한다.")
-    @DeleteMapping
-    public ApiResult<DeleteFriendDto.Response> deleteFriend(@RequestBody DeleteFriendDto.Request request) {
-        return ok(friendService.deleteFriend(request));
+    @DeleteMapping(value = "/{userId}/{friendId}")
+    public ApiResult<DeleteFriendDto.Response> deleteFriend(
+            @PathVariable long userId,
+            @PathVariable long friendId
+    ) {
+        return ok(friendService.deleteFriend(userId, friendId));
     }
 }

--- a/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/friend/dto/DeleteFriendDto.java
+++ b/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/friend/dto/DeleteFriendDto.java
@@ -10,17 +10,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class DeleteFriendDto {
 
-    @ApiModel(value = "DeleteFriend.Request", description = "nested class in DeleteFriendDto")
-    @Getter
-    @AllArgsConstructor
-    public static class Request {
-        @ApiModelProperty(value = "사용자 번호")
-        private final Long userId;
-
-        @ApiModelProperty(value = "삭제할 친구 번호")
-        private final Long friendId;
-    }
-
     @ApiModel(value = "DeleteFriend.Response", description = "nested class in DeleteFriendDto")
     @Getter
     @AllArgsConstructor

--- a/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/friend/dto/FindFriendsDto.java
+++ b/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/friend/dto/FindFriendsDto.java
@@ -2,7 +2,6 @@ package com.kds.ourmemory.controller.v1.friend.dto;
 
 import com.kds.ourmemory.entity.friend.Friend;
 import com.kds.ourmemory.entity.friend.FriendStatus;
-import com.kds.ourmemory.entity.user.User;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AccessLevel;
@@ -25,8 +24,8 @@ public class FindFriendsDto {
         private final FriendStatus status;
 
         public Response(Friend friend) {
-            friendId = friend.getFriend().getId();
-            name = friend.getFriend().getName();
+            friendId = friend.getFriendUser().getId();
+            name = friend.getFriendUser().getName();
             this.status = friend.getStatus();
         }
     }

--- a/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/memory/MemoryController.java
+++ b/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/memory/MemoryController.java
@@ -1,11 +1,7 @@
 package com.kds.ourmemory.controller.v1.memory;
 
 import com.kds.ourmemory.controller.v1.ApiResult;
-import com.kds.ourmemory.controller.v1.memory.dto.DeleteMemoryDto;
-import com.kds.ourmemory.controller.v1.memory.dto.FindMemoriesDto;
-import com.kds.ourmemory.controller.v1.memory.dto.FindMemoryDto;
-import com.kds.ourmemory.controller.v1.memory.dto.InsertMemoryDto;
-import com.kds.ourmemory.entity.memory.Memory;
+import com.kds.ourmemory.controller.v1.memory.dto.*;
 import com.kds.ourmemory.service.v1.memory.MemoryService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -13,10 +9,7 @@ import io.swagger.annotations.ApiParam;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
-import java.time.LocalDateTime;
-import java.util.Comparator;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static com.kds.ourmemory.controller.v1.ApiResult.ok;
 
@@ -36,27 +29,32 @@ public class MemoryController {
     @ApiOperation(value = "일정 개별 조회")
     @GetMapping("/{memoryId}")
     public ApiResult<FindMemoryDto.Response> findMemory(
-            @ApiParam(value = "memoryId", required = true) @PathVariable long memoryId) {
+            @PathVariable long memoryId) {
         return ok(memoryService.find(memoryId));
     }
 
-    @ApiOperation(value = "개인 일정 목록 조회", notes = "사용자가 생성했거나 참여중인 일정을 조회한다.")
+    @ApiOperation(value = "일정 목록 조회", notes = "조건에 맞는 일정을 검색한다.")
     @GetMapping
     public ApiResult<List<FindMemoriesDto.Response>> findMemories(
-            @ApiParam(value = "userId", required = true) @RequestParam Long userId) {
-        return ok(memoryService.findMemories(userId).stream()
-                .filter(Memory::isUsed)
-                .sorted(Comparator.comparing(Memory::getStartDate)) // first order
-                .filter(memory -> memory.getStartDate().isAfter(LocalDateTime.now()))
-                .sorted(Comparator.comparing(Memory::getEndDate))   // second order
-                .map(FindMemoriesDto.Response::new)
-                .collect(Collectors.toList()));
+            @ApiParam(value = "사용자 번호, 일정 작성자 혹은 참여자") @RequestParam(required = false) Long userId,
+            @ApiParam(value = "일정 제목") @RequestParam(required = false) String name
+    ) {
+        return ok(memoryService.findMemories(userId, name));
     }
 
-    @ApiOperation(value = "일정 삭제", notes = "일정 삭제, 사용자-일정-방 연결된 관계 삭제")
+    @ApiOperation(value = "일정 수정", notes = "전달받은 값이 있는 경우 수정")
+    @PutMapping("/{memoryId}")
+    public ApiResult<UpdateMemoryDto.Response> update(
+            @PathVariable long memoryId,
+            @RequestParam UpdateMemoryDto.Request request
+    ) {
+        return ok(memoryService.update(memoryId, request));
+    }
+
+    @ApiOperation(value = "일정 삭제", notes = "일정 삭제 처리")
     @DeleteMapping("/{memoryId}")
     public ApiResult<DeleteMemoryDto.Response> delete(
-            @ApiParam(value = "memoryId", required = true) @PathVariable long memoryId) {
+            @PathVariable long memoryId) {
         return ok(memoryService.delete(memoryId));
     }
 }

--- a/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/memory/MemoryController.java
+++ b/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/memory/MemoryController.java
@@ -1,11 +1,7 @@
 package com.kds.ourmemory.controller.v1.memory;
 
 import com.kds.ourmemory.controller.v1.ApiResult;
-import com.kds.ourmemory.controller.v1.memory.dto.DeleteMemoryDto;
-import com.kds.ourmemory.controller.v1.memory.dto.FindMemoriesDto;
-import com.kds.ourmemory.controller.v1.memory.dto.FindMemoryDto;
-import com.kds.ourmemory.controller.v1.memory.dto.InsertMemoryDto;
-import com.kds.ourmemory.entity.memory.Memory;
+import com.kds.ourmemory.controller.v1.memory.dto.*;
 import com.kds.ourmemory.service.v1.memory.MemoryService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -13,9 +9,7 @@ import io.swagger.annotations.ApiParam;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.Comparator;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static com.kds.ourmemory.controller.v1.ApiResult.ok;
 
@@ -35,26 +29,32 @@ public class MemoryController {
     @ApiOperation(value = "일정 개별 조회")
     @GetMapping("/{memoryId}")
     public ApiResult<FindMemoryDto.Response> findMemory(
-            @ApiParam(value = "memoryId", required = true) @PathVariable long memoryId) {
+            @PathVariable long memoryId) {
         return ok(memoryService.find(memoryId));
     }
 
-    @ApiOperation(value = "개인 일정 목록 조회", notes = "사용자가 생성했거나 참여중인 일정을 조회한다.")
+    @ApiOperation(value = "일정 목록 조회", notes = "조건에 맞는 일정을 검색한다.")
     @GetMapping
     public ApiResult<List<FindMemoriesDto.Response>> findMemories(
-            @ApiParam(value = "userId", required = true) @RequestParam Long userId) {
-        return ok(memoryService.findMemories(userId).stream()
-                .filter(Memory::isUsed)
-                .sorted(Comparator.comparing(Memory::getStartDate)) // first order
-                .sorted(Comparator.comparing(Memory::getEndDate))   // second order
-                .map(FindMemoriesDto.Response::new)
-                .collect(Collectors.toList()));
+            @ApiParam(value = "사용자 번호, 일정 작성자 혹은 참여자") @RequestParam(required = false) Long userId,
+            @ApiParam(value = "일정 제목") @RequestParam(required = false) String name
+    ) {
+        return ok(memoryService.findMemories(userId, name));
     }
 
-    @ApiOperation(value = "일정 삭제", notes = "일정 삭제, 사용자-일정-방 연결된 관계 삭제")
+    @ApiOperation(value = "일정 수정", notes = "전달받은 값이 있는 경우 수정")
+    @PutMapping("/{memoryId}")
+    public ApiResult<UpdateMemoryDto.Response> update(
+            @PathVariable long memoryId,
+            @RequestParam UpdateMemoryDto.Request request
+    ) {
+        return ok(memoryService.update(memoryId, request));
+    }
+
+    @ApiOperation(value = "일정 삭제", notes = "일정 삭제 처리")
     @DeleteMapping("/{memoryId}")
     public ApiResult<DeleteMemoryDto.Response> delete(
-            @ApiParam(value = "memoryId", required = true) @PathVariable long memoryId) {
+            @PathVariable long memoryId) {
         return ok(memoryService.delete(memoryId));
     }
 }

--- a/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/memory/dto/DeleteMemoryDto.java
+++ b/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/memory/dto/DeleteMemoryDto.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class DeleteMemoryDto {
 
-    @ApiModel(value = "DeleteMemory.Response", description = "nested class in DeleteMemoryDto")
+    @ApiModel(value = "DeleteMemoryDto.Response", description = "nested class in DeleteMemoryDto")
     @Getter
     @AllArgsConstructor
     public static class Response {

--- a/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/memory/dto/FindMemoriesDto.java
+++ b/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/memory/dto/FindMemoriesDto.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiModelProperty;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -16,8 +17,9 @@ import java.util.stream.Collectors;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class FindMemoriesDto {
 
-    @ApiModel(value = "FindMemories.Response", description = "nested class in FindMemoriesDto")
+    @ApiModel(value = "FindMemoriesResponse", description = "nested class in FindMemoriesDto")
     @Getter
+    @ToString
     public static class Response {
         @ApiModelProperty(value = "일정 번호", example = "5")
         private final Long memoryId;
@@ -75,7 +77,6 @@ public class FindMemoriesDto {
             secondAlarm = memory.getSecondAlarm();
             regDate = memory.formatRegDate();
             modDate = memory.formatModDate();
-            
             members = memory.getUsers().stream().filter(User::isUsed).map(Member::new)
                     .collect(Collectors.toList());
         }
@@ -83,7 +84,7 @@ public class FindMemoriesDto {
         /**
          * Memory member non static inner class
          */
-        @ApiModel(value = "FindMemories.Response.Member", description = "inner class in FindMemoriesDto.Response")
+        @ApiModel(value = "FindMemoriesResponse.Member", description = "inner class in FindMemoriesDto.Response")
         @Getter
         private class Member {
             @ApiModelProperty(value = "사용자 번호", example = "49")

--- a/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/memory/dto/FindMemoryDto.java
+++ b/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/memory/dto/FindMemoryDto.java
@@ -16,7 +16,7 @@ import java.util.stream.Collectors;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class FindMemoryDto {
 
-    @ApiModel(value = "FindMemory.Response", description = "nested class in FindMemoryDto")
+    @ApiModel(value = "FindMemoryDto.Response", description = "nested class in FindMemoryDto")
     @Getter
     public static class Response {
         @ApiModelProperty(value = "일정 번호", example = "5")
@@ -75,7 +75,6 @@ public class FindMemoryDto {
             secondAlarm = memory.getSecondAlarm();
             regDate = memory.formatRegDate();
             modDate = memory.formatModDate();
-
             members = memory.getUsers().stream().filter(User::isUsed).map(FindMemoryDto.Response.Member::new)
                     .collect(Collectors.toList());
         }
@@ -83,7 +82,7 @@ public class FindMemoryDto {
         /**
          * Memory member non static inner class
          */
-        @ApiModel(value = "FindMemory.Response.Member", description = "inner class in FindMemory.Response")
+        @ApiModel(value = "FindMemoryDto.Response.Member", description = "inner class in FindMemory.Response")
         @Getter
         private class Member {
             @ApiModelProperty(value = "사용자 번호", example = "49")

--- a/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/memory/dto/InsertMemoryDto.java
+++ b/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/memory/dto/InsertMemoryDto.java
@@ -2,9 +2,12 @@ package com.kds.ourmemory.controller.v1.memory.dto;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 
+import com.kds.ourmemory.entity.memory.Memory;
+import com.kds.ourmemory.entity.user.User;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AccessLevel;
@@ -15,7 +18,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class InsertMemoryDto {
 
-    @ApiModel(value = "InsertMemory.Request", description = "nested class in InsertMemoryDto")
+    @ApiModel(value = "InsertMemoryDto.Request", description = "nested class in InsertMemoryDto")
     @Getter
     @AllArgsConstructor
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -61,17 +64,101 @@ public class InsertMemoryDto {
         private List<Long> shareRooms;
     }
 
-    @ApiModel(value = "InsertMemory.Response", description = "nested class in InsertMemoryDto")
+    @ApiModel(value = "InsertMemoryDto.Response", description = "nested class in InsertMemoryDto")
     @Getter
-    @AllArgsConstructor
     public static class Response {
-        @ApiModelProperty(value = "일정 번호", example = "3")
-        private final long memoryId;
-        
-        @ApiModelProperty(value = "방 번호", notes = "일정이 포함된 기준 방의 번호, 방에 포함되지 않는 경우 null 리턴됨.", example = "65")
-        private final Long roomId;
-        
-        @ApiModelProperty(value="일정 추가한 날짜", notes = "yyyy-MM-dd HH:mm:ss", example = "2021-04-20 14:49:33")
-        private final String addDate;
+        @ApiModelProperty(value = "일정 번호", example = "5")
+        private final Long memoryId;
+
+        @ApiModelProperty(value = "일정 작성자 번호", example = "64")
+        private final Long writerId;
+
+        @ApiModelProperty(value = "일정 제목", example = "회의 일정")
+        private final String name;
+
+        @ApiModelProperty(value = "일정 내용", example = "주간 회의")
+        private final String contents;
+
+        @ApiModelProperty(value = "장소", example = "신도림역 1번 출구")
+        private final String place;
+
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
+        @ApiModelProperty(value = "시작 시간", notes = "yyyy-MM-dd HH:mm")
+        private final LocalDateTime startDate;
+
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
+        @ApiModelProperty(value = "종료 시간", notes = "yyyy-MM-dd HH:mm")
+        private final LocalDateTime endDate;
+
+        @ApiModelProperty(value = "배경색", example = "#FFFFFF")
+        private final String bgColor;
+
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
+        @ApiModelProperty(value = "첫 번째 알림 시간", notes = "yyyy-MM-dd HH:mm")
+        private final LocalDateTime firstAlarm;
+
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
+        @ApiModelProperty(value = "두 번째 알림 시간", notes = "yyyy-MM-dd HH:mm")
+        private final LocalDateTime secondAlarm;
+
+        @ApiModelProperty(value = "일정 등록날짜", notes = "yyyy-MM-dd HH:mm:ss")
+        private final String regDate;
+
+        @ApiModelProperty(value = "일정 수정날짜", notes = "yyyy-MM-dd HH:mm:ss")
+        private final String modDate;
+
+        @ApiModelProperty(value = "일정 참여자", notes = "일정을 생성한 사람도 참여자에 포함되어 전달됨.", example = "[{참여자1}, {참여자2}]")
+        private final List<Member> members;
+
+        @ApiModelProperty(value = "일정 메인 방", notes = "일정이 포함되는 메인 방 번호를 전달한다. 개인 일정인 경우 null 을 전달함.")
+        private final Long mainRoomId;
+
+        public Response(Memory memory, Long mainRoomId) {
+            memoryId = memory.getId();
+            writerId = memory.getWriter().getId();
+            name = memory.getName();
+            contents = memory.getContents();
+            place = memory.getPlace();
+            startDate = memory.getStartDate();
+            endDate = memory.getEndDate();
+            bgColor = memory.getBgColor();
+            firstAlarm = memory.getFirstAlarm();
+            secondAlarm = memory.getSecondAlarm();
+            regDate = memory.formatRegDate();
+            modDate = memory.formatModDate();
+            members = memory.getUsers().stream().filter(User::isUsed).map(Member::new)
+                    .collect(Collectors.toList());
+            this.mainRoomId = mainRoomId;
+        }
+
+        /**
+         * Memory member non static inner class
+         */
+        @ApiModel(value = "InsertMemoryDto.Response.Member", description = "inner class in InsertMemoryDto.Response")
+        @Getter
+        private class Member {
+            @ApiModelProperty(value = "사용자 번호", example = "49")
+            private final Long userId;
+
+            @ApiModelProperty(value = "사용자 이름", example = "김동영")
+            private final String name;
+
+            @ApiModelProperty(value = "사용자 생일", example = "null")
+            private final String birthday;
+
+            @ApiModelProperty(value = "양력 여부", example = "true")
+            private final boolean solar;
+
+            @ApiModelProperty(value = "생일 공개여부", example = "false")
+            private final boolean birthdayOpen;
+
+            public Member(User user) {
+                userId = user.getId();
+                name = user.getName();
+                birthday = user.isBirthdayOpen() ? user.getBirthday() : null;
+                solar = user.isSolar();
+                birthdayOpen = user.isBirthdayOpen();
+            }
+        }
     }
 }

--- a/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/memory/dto/UpdateMemoryDto.java
+++ b/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/memory/dto/UpdateMemoryDto.java
@@ -9,7 +9,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class UpdateMemoryDto {
@@ -21,9 +20,6 @@ public class UpdateMemoryDto {
     public static class Request {
         @ApiModelProperty(value = "일정 이름", example = "회의 일정")
         private String name;
-
-        @ApiModelProperty(value = "일정 참여자 번호", notes = "참여자가 방에 포함된 사람과 다르거나 많을 경우, 방을 새로 생성한다.", example = "[2,4,5]")
-        private List<Long> members;
 
         @ApiModelProperty(value = "일정 내용")
         private String contents;

--- a/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/memory/dto/UpdateMemoryDto.java
+++ b/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/memory/dto/UpdateMemoryDto.java
@@ -1,0 +1,61 @@
+package com.kds.ourmemory.controller.v1.memory.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class UpdateMemoryDto {
+
+    @ApiModel(value = "UpdateMemoryDto.Request", description = "nested class in UpdateMemoryDto")
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class Request {
+        @ApiModelProperty(value = "일정 이름", example = "회의 일정")
+        private String name;
+
+        @ApiModelProperty(value = "일정 참여자 번호", notes = "참여자가 방에 포함된 사람과 다르거나 많을 경우, 방을 새로 생성한다.", example = "[2,4,5]")
+        private List<Long> members;
+
+        @ApiModelProperty(value = "일정 내용")
+        private String contents;
+
+        @ApiModelProperty(value = "장소")
+        private String place;
+
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
+        @ApiModelProperty(value = "시작 시간", notes = "yyyy-MM-dd HH:mm", example = "2021-04-03 19:00")
+        private LocalDateTime startDate;
+
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
+        @ApiModelProperty(value = "종료 시간", notes = "yyyy-MM-dd HH:mm", example = "2021-04-03 21:00")
+        private LocalDateTime endDate;
+
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
+        @ApiModelProperty(value = "첫 번째 알림 시간", notes = "yyyy-MM-dd HH:mm", example = "2021-04-01 12:00")
+        private LocalDateTime firstAlarm;
+
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
+        @ApiModelProperty(value = "두 번째 알림 시간", notes = "yyyy-MM-dd HH:mm", example = "2021-04-02 12:00")
+        private LocalDateTime secondAlarm;
+
+        @ApiModelProperty(value = "배경색", example = "#FFFFFF")
+        private String bgColor;
+    }
+
+    @ApiModel(value = "UpdateMemoryDto.Response", description = "nested class in UpdateMemoryDto")
+    @Getter
+    @AllArgsConstructor
+    public static class Response {
+        @ApiModelProperty(value = "수정 날짜", notes = "yyyy-MM-dd HH:mm:ss", example = "2021-07-06 23:58:33")
+        private final String updateDate;
+    }
+}

--- a/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/room/RoomController.java
+++ b/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/room/RoomController.java
@@ -40,7 +40,6 @@ public class RoomController {
             @RequestParam(required = false) String name
     ) {
         return ok(roomService.findRooms(userId, name).stream()
-                .filter(Room::isUsed)
                 .map(FindRoomsDto.Response::new)
                 .collect(Collectors.toList()));
     }

--- a/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/room/dto/UpdateRoomDto.java
+++ b/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/room/dto/UpdateRoomDto.java
@@ -10,12 +10,11 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class UpdateRoomDto {
 
-    @ApiModel(value = "PutRoomDto.Request", description = "nested class in PutRoomDto")
+    @ApiModel(value = "UpdateRoomDto.Request", description = "nested class in UpdateRoomDto")
     @Getter
     @AllArgsConstructor
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
     public static class Request {
-
         @ApiModelProperty(value = "방 이름")
         private String name;
 
@@ -23,9 +22,9 @@ public class UpdateRoomDto {
         private Boolean opened;
     }
 
-    @ApiModel(value = "PutRoomDto.Response", description = "nested class in PutRoomDto")
-    @AllArgsConstructor
+    @ApiModel(value = "UpdateRoomDto.Response", description = "nested class in UpdateRoomDto")
     @Getter
+    @AllArgsConstructor
     public static class Response {
         @ApiModelProperty(value = "수정 날짜", notes = "yyyy-MM-dd HH:mm:ss", example = "2021-07-05 22:03:33")
         private final String updateDate;

--- a/OurMemory_Server/src/main/java/com/kds/ourmemory/entity/friend/Friend.java
+++ b/OurMemory_Server/src/main/java/com/kds/ourmemory/entity/friend/Friend.java
@@ -26,18 +26,18 @@ public class Friend extends BaseTimeEntity {
 	@Id
 	@ManyToOne(targetEntity = User.class)
 	@JoinColumn(name = "friend_id", foreignKey = @ForeignKey(name = "friends_friend_id"))
-	private User friend;
+	private User friendUser;
 
-	@Column(nullable = false, name = "friend_status")
+	@Column(nullable = false, name = "friend_status", columnDefinition = "comment 'WAIT, REQUESTED_BY, FRIEND, BLOCK'")
 	@Enumerated(EnumType.STRING)
 	private FriendStatus status;
 
-	public Friend(User user, User friend, FriendStatus status) {
+	public Friend(User user, User friendUser, FriendStatus status) {
 		checkNotNull(user, "사용자 정보가 없습니다. 사용자 번호를 확인해주세요.");
-		checkNotNull(friend, "친구 정보가 없습니다. 친구 번호를 확인해주세요.");
+		checkNotNull(friendUser, "친구 정보가 없습니다. 친구 번호를 확인해주세요.");
 
 		this.user = user;
-		this.friend = friend;
+		this.friendUser = friendUser;
 		this.status = status;
 	}
 

--- a/OurMemory_Server/src/main/java/com/kds/ourmemory/entity/friend/FriendId.java
+++ b/OurMemory_Server/src/main/java/com/kds/ourmemory/entity/friend/FriendId.java
@@ -11,5 +11,5 @@ import java.io.Serializable;
 @AllArgsConstructor
 public class FriendId implements Serializable {
     private Long user;
-    private Long friend;
+    private Long friendUser;
 }

--- a/OurMemory_Server/src/main/java/com/kds/ourmemory/entity/memory/Memory.java
+++ b/OurMemory_Server/src/main/java/com/kds/ourmemory/entity/memory/Memory.java
@@ -1,37 +1,24 @@
 package com.kds.ourmemory.entity.memory;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.base.Preconditions.checkArgument;
+import com.kds.ourmemory.controller.v1.memory.dto.UpdateMemoryDto;
+import com.kds.ourmemory.entity.BaseTimeEntity;
+import com.kds.ourmemory.entity.room.Room;
+import com.kds.ourmemory.entity.user.User;
+import lombok.*;
+import org.hibernate.annotations.DynamicUpdate;
 
+import javax.persistence.*;
 import java.io.Serial;
 import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.function.BiConsumer;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.ForeignKey;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToMany;
-import javax.persistence.ManyToOne;
-
-import org.hibernate.annotations.DynamicUpdate;
-
-import com.kds.ourmemory.entity.BaseTimeEntity;
-import com.kds.ourmemory.entity.room.Room;
-import com.kds.ourmemory.entity.user.User;
-
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 @ToString(exclude = {"rooms", "users"})
 @DynamicUpdate
@@ -39,8 +26,9 @@ import lombok.ToString;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Memory extends BaseTimeEntity implements Serializable {
+
     @Serial
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 3L;
 
     @Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -115,21 +103,33 @@ public class Memory extends BaseTimeEntity implements Serializable {
         this.rooms = this.rooms==null? new ArrayList<>() : this.rooms;
         this.rooms.add(room);
     }
-    
-    public Optional<Memory> addRooms(List<Room> rooms) {
-        this.rooms = this.rooms==null? new ArrayList<>() : this.rooms;
-        this.rooms.addAll(rooms);
-        return Optional.of(this);
-    }
-    
+
     public void addUser(User user) {
         this.users = this.users==null? new ArrayList<>() : this.users;
         this.users.add(user);
     }
-    
-    public Optional<Memory> addUsers(List<User> users) {
-        this.users = this.users==null? new ArrayList<>() : this.users;
-        this.users.addAll(users);
-        return Optional.of(this);
+
+    public Optional<Memory> updateMemory(UpdateMemoryDto.Request request) {
+        return Optional.ofNullable(request)
+                .map(req -> {
+                    updateColumn.accept(name, req.getName());
+                    updateColumn.accept(users, req.getMembers());
+                    updateColumn.accept(contents, req.getContents());
+                    updateColumn.accept(place, req.getPlace());
+                    updateColumn.accept(startDate, req.getStartDate());
+                    updateColumn.accept(endDate, req.getEndDate());
+                    updateColumn.accept(firstAlarm, req.getFirstAlarm());
+                    updateColumn.accept(secondAlarm, req.getSecondAlarm());
+                    updateColumn.accept(bgColor, req.getBgColor());
+
+                    return this;
+                });
     }
+
+    public Memory deleteMemory() {
+	    this.used = false;
+	    return this;
+    }
+
+    private static final BiConsumer<Object, Object> updateColumn = (col, value) -> col = Objects.nonNull(value) ? value : col;
 }

--- a/OurMemory_Server/src/main/java/com/kds/ourmemory/entity/memory/Memory.java
+++ b/OurMemory_Server/src/main/java/com/kds/ourmemory/entity/memory/Memory.java
@@ -15,7 +15,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.function.BiConsumer;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -112,15 +111,14 @@ public class Memory extends BaseTimeEntity implements Serializable {
     public Optional<Memory> updateMemory(UpdateMemoryDto.Request request) {
         return Optional.ofNullable(request)
                 .map(req -> {
-                    updateColumn.accept(name, req.getName());
-                    updateColumn.accept(users, req.getMembers());
-                    updateColumn.accept(contents, req.getContents());
-                    updateColumn.accept(place, req.getPlace());
-                    updateColumn.accept(startDate, req.getStartDate());
-                    updateColumn.accept(endDate, req.getEndDate());
-                    updateColumn.accept(firstAlarm, req.getFirstAlarm());
-                    updateColumn.accept(secondAlarm, req.getSecondAlarm());
-                    updateColumn.accept(bgColor, req.getBgColor());
+                    name = Objects.nonNull(req.getName()) ? req.getName() : name;
+                    contents = Objects.nonNull(req.getContents()) ? req.getContents() : contents;
+                    place = Objects.nonNull(req.getPlace()) ? req.getPlace() : place;
+                    startDate = Objects.nonNull(req.getStartDate()) ? req.getStartDate() : startDate;
+                    endDate = Objects.nonNull(req.getEndDate()) ? req.getEndDate() : endDate;
+                    firstAlarm = Objects.nonNull(req.getFirstAlarm()) ? req.getFirstAlarm() : firstAlarm;
+                    secondAlarm = Objects.nonNull(req.getSecondAlarm()) ? req.getSecondAlarm() : secondAlarm;
+                    bgColor = Objects.nonNull(req.getBgColor()) ? req.getBgColor() : bgColor;
 
                     return this;
                 });
@@ -130,6 +128,4 @@ public class Memory extends BaseTimeEntity implements Serializable {
 	    this.used = false;
 	    return this;
     }
-
-    private static final BiConsumer<Object, Object> updateColumn = (col, value) -> col = Objects.nonNull(value) ? value : col;
 }

--- a/OurMemory_Server/src/main/java/com/kds/ourmemory/entity/room/Room.java
+++ b/OurMemory_Server/src/main/java/com/kds/ourmemory/entity/room/Room.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.BiConsumer;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -25,7 +26,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public class Room extends BaseTimeEntity implements Serializable{
 
 	@Serial
-	private static final long serialVersionUID = 1L;
+	private static final long serialVersionUID = 2L;
 
     @Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -79,8 +80,9 @@ public class Room extends BaseTimeEntity implements Serializable{
 	public Optional<Room> updateRoom(UpdateRoomDto.Request request) {
 		return Optional.ofNullable(request)
 				.map(req -> {
-					name = Objects.nonNull(req.getName()) ? req.getName() : name;
-					opened = Objects.nonNull(req.getOpened()) ? req.getOpened() : opened;
+					updateColumn.accept(name, req.getName());
+					updateColumn.accept(opened, req.getOpened());
+
 					return this;
 				});
 	}
@@ -89,4 +91,6 @@ public class Room extends BaseTimeEntity implements Serializable{
 		used = false;
 		return this;
 	}
+
+	private final BiConsumer<Object, Object> updateColumn = (col, value) -> col = Objects.nonNull(value) ? value : col;
 }

--- a/OurMemory_Server/src/main/java/com/kds/ourmemory/entity/room/Room.java
+++ b/OurMemory_Server/src/main/java/com/kds/ourmemory/entity/room/Room.java
@@ -14,7 +14,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.function.BiConsumer;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -80,8 +79,8 @@ public class Room extends BaseTimeEntity implements Serializable{
 	public Optional<Room> updateRoom(UpdateRoomDto.Request request) {
 		return Optional.ofNullable(request)
 				.map(req -> {
-					updateColumn.accept(name, req.getName());
-					updateColumn.accept(opened, req.getOpened());
+					name = Objects.nonNull(req.getName()) ? req.getName() : name;
+					opened = Objects.nonNull(req.getOpened()) ? req.getOpened() : opened;
 
 					return this;
 				});
@@ -92,5 +91,8 @@ public class Room extends BaseTimeEntity implements Serializable{
 		return this;
 	}
 
-	private final BiConsumer<Object, Object> updateColumn = (col, value) -> col = Objects.nonNull(value) ? value : col;
+	public Room deleteMemory(Memory memory) {
+		memories.stream().filter(m -> m.equals(memory)).forEach(Memory::deleteMemory);
+		return this;
+	}
 }

--- a/OurMemory_Server/src/main/java/com/kds/ourmemory/repository/friend/FriendRepository.java
+++ b/OurMemory_Server/src/main/java/com/kds/ourmemory/repository/friend/FriendRepository.java
@@ -2,7 +2,6 @@ package com.kds.ourmemory.repository.friend;
 
 import com.kds.ourmemory.entity.friend.Friend;
 import com.kds.ourmemory.entity.friend.FriendId;
-import com.kds.ourmemory.entity.friend.FriendStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import javax.transaction.Transactional;
@@ -12,5 +11,5 @@ import java.util.Optional;
 @Transactional
 public interface FriendRepository extends JpaRepository<Friend, FriendId> {
     Optional<List<Friend>> findByUserId(Long userId);
-    Optional<Friend> findByUserIdAndFriendId(Long userId, Long friendId);
+    Optional<Friend> findByUserIdAndFriendUserId(Long userId, Long friendId);
 }

--- a/OurMemory_Server/src/main/java/com/kds/ourmemory/repository/memory/MemoryRepository.java
+++ b/OurMemory_Server/src/main/java/com/kds/ourmemory/repository/memory/MemoryRepository.java
@@ -1,11 +1,13 @@
 package com.kds.ourmemory.repository.memory;
 
-import javax.transaction.Transactional;
-
+import com.kds.ourmemory.entity.memory.Memory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import com.kds.ourmemory.entity.memory.Memory;
+import javax.transaction.Transactional;
+import java.util.List;
+import java.util.Optional;
 
 @Transactional
 public interface MemoryRepository extends JpaRepository<Memory, Long> {
+    public Optional<List<Memory>> findAllByName(String name);
 }

--- a/OurMemory_Server/src/main/java/com/kds/ourmemory/repository/room/RoomRepository.java
+++ b/OurMemory_Server/src/main/java/com/kds/ourmemory/repository/room/RoomRepository.java
@@ -1,7 +1,6 @@
 package com.kds.ourmemory.repository.room;
 
 import com.kds.ourmemory.entity.room.Room;
-import com.kds.ourmemory.entity.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import javax.transaction.Transactional;
@@ -10,5 +9,5 @@ import java.util.Optional;
 
 @Transactional
 public interface RoomRepository extends JpaRepository<Room, Long> {
-    Optional<List<Room>> findAllByOwnerOrName(User user, String name);
+    Optional<List<Room>> findAllByName(String name);
 }

--- a/OurMemory_Server/src/main/java/com/kds/ourmemory/service/v1/memory/MemoryService.java
+++ b/OurMemory_Server/src/main/java/com/kds/ourmemory/service/v1/memory/MemoryService.java
@@ -5,9 +5,7 @@ import com.kds.ourmemory.advice.v1.memory.exception.MemoryNotFoundException;
 import com.kds.ourmemory.advice.v1.memory.exception.MemoryNotFoundRoomException;
 import com.kds.ourmemory.advice.v1.memory.exception.MemoryNotFoundWriterException;
 import com.kds.ourmemory.controller.v1.firebase.dto.FcmDto;
-import com.kds.ourmemory.controller.v1.memory.dto.DeleteMemoryDto;
-import com.kds.ourmemory.controller.v1.memory.dto.FindMemoryDto;
-import com.kds.ourmemory.controller.v1.memory.dto.InsertMemoryDto;
+import com.kds.ourmemory.controller.v1.memory.dto.*;
 import com.kds.ourmemory.controller.v1.room.dto.InsertRoomDto;
 import com.kds.ourmemory.entity.BaseTimeEntity;
 import com.kds.ourmemory.entity.memory.Memory;
@@ -23,9 +21,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
@@ -44,24 +40,26 @@ public class MemoryService {
 
     // Add to FCM
     private final FcmService fcmService;
+
+    private static final String NOT_FOUND_MESSAGE = "Not found %s matched id: %d";
     
     @Transactional
     public InsertMemoryDto.Response insert(InsertMemoryDto.Request request) {
         return findUser(request.getUserId())
                 .map(writer -> {
                     var memory = Memory.builder()
-                        .writer(writer)
-                        .name(request.getName())
-                        .contents(request.getContents())
-                        .place(request.getPlace())
-                        .startDate(request.getStartDate())
-                        .endDate(request.getEndDate())
-                        .firstAlarm(request.getFirstAlarm())
-                        .secondAlarm(request.getSecondAlarm())
-                        .bgColor(request.getBgColor())
-                        .used(true)
-                        .build();
-                    
+                            .writer(writer)
+                            .name(request.getName())
+                            .contents(request.getContents())
+                            .place(request.getPlace())
+                            .startDate(request.getStartDate())
+                            .endDate(request.getEndDate())
+                            .firstAlarm(request.getFirstAlarm())
+                            .secondAlarm(request.getSecondAlarm())
+                            .bgColor(request.getBgColor())
+                            .used(true)
+                            .build();
+
                     return insertMemory(memory)
                             .orElseThrow(() -> new MemoryInternalServerException(
                                     String.format("Memory '%s' insert failed.", memory.getName())));
@@ -70,45 +68,52 @@ public class MemoryService {
                     // Relation memory and writer
                     memory.getWriter().addMemory(memory);
                     memory.addUser(memory.getWriter());
-                    
+
                     // Relation memory and members
                     relationMemoryToMembers(memory, request.getMembers());
                     relationMemoryToRoom(memory, request.getShareRooms());
-                    Long roomId = relationMainRoom(memory, request);
-                    
-                    return new InsertMemoryDto.Response(memory.getId(), roomId, memory.formatRegDate());
+                    var roomId = relationMainRoom(memory, request);
+
+                    return new InsertMemoryDto.Response(memory, roomId);
                 })
                 .orElseThrow(() -> new MemoryNotFoundWriterException(
-                        "Not found writer matched to userId: " + request.getUserId()));
-    }
-
-    @Transactional
-    private void relationMemoryToRoom(Memory memory, List<Long> roomIds) {
-        Optional.ofNullable(roomIds)
-                .filter(ids -> !ids.isEmpty())
-                .ifPresent(ids -> ids.forEach(id -> findRoom(id)
-                                .map(room -> {
-                                    room.addMemory(memory);
-                                    memory.addRoom(room);
-
-                                    room.getUsers().forEach(user -> fcmService.sendMessageTo(
-                                            new FcmDto.Request(user.getPushToken(), user.getDeviceOs(),
-                                                    "OurMemory - 일정 공유", String.format("'%s' 일정이 방에 공유되었습니다.", memory.getName())))
-                                    );
-
-                                    return room;
-                                })
-                                .orElseThrow(() -> new MemoryNotFoundRoomException("Not found room matched roomId: " + id))
+                                String.format(NOT_FOUND_MESSAGE, "writer", request.getUserId())
                         )
                 );
     }
 
     @Transactional
+    private void relationMemoryToRoom(Memory memory, List<Long> roomIds) {
+        Optional.ofNullable(roomIds)
+                .map(List::stream).ifPresent(stream -> stream.forEach(id ->
+                findRoom(id)
+                        .map(room -> {
+                            room.addMemory(memory);
+                            memory.addRoom(room);
+
+                            room.getUsers().forEach(user -> fcmService.sendMessageTo(
+                                    FcmDto.Request.builder()
+                                            .token(user.getPushToken())
+                                            .deviceOs(user.getDeviceOs())
+                                            .title("OurMemory - 일정 공유")
+                                            .body(String.format("'%s' 일정이 방에 공유되었습니다.", memory.getName()))
+                                            .build()
+
+                                    )
+                            );
+                            return room;
+                        })
+                        .orElseThrow(() -> new MemoryNotFoundRoomException(
+                                        String.format(NOT_FOUND_MESSAGE, "room", id)
+                                )
+                        )
+        ));
+    }
+    
+    @Transactional
     private void relationMemoryToMembers(Memory memory, List<Long> members) {
         Optional.ofNullable(members)
-                .filter(m -> !m.isEmpty())
-                .ifPresent(mem -> mem.forEach(id -> findUser(id)
-                        .map(user -> {
+                .ifPresent(mem -> mem.forEach(id -> findUser(id).map(user -> {
                             user.addMemory(memory);
                             memory.addUser(user);
 
@@ -116,8 +121,11 @@ public class MemoryService {
                                     "OurMemory - 일정 공유", String.format("'%s' 일정에 참여되셨습니다.", memory.getName())));
                             return user;
                         })
-                        .orElseThrow(() -> new MemoryNotFoundRoomException("Not found room matched roomId: " + id)))
-                );
+                        .orElseThrow(() -> new MemoryNotFoundRoomException(
+                                String.format(NOT_FOUND_MESSAGE, "room", id))
+                        )
+                )
+        );
     }
 
     /**
@@ -145,7 +153,6 @@ public class MemoryService {
                 })
                 // 1-2) Participants are not included in the main room OR 2. If there is no main room
                 .orElseGet(() -> Optional.ofNullable(request.getMembers())
-                        .filter(members -> !members.isEmpty())
                         // 1) If there are participants -> Create room and push notification
                         .map(members -> {
                             // Create make room protocol
@@ -155,24 +162,31 @@ public class MemoryService {
                             Long owner = memory.getWriter().getId();
                             var insertRoomRequestDto = new InsertRoomDto.Request(name, owner, false,
                                     request.getMembers());
-                            
+
                             // make room
                             var insertRoomResponseDto = roomService.insert(insertRoomRequestDto);
 
                             // push message
                             return findRoom(insertRoomResponseDto.getRoomId()).map(room -> {
                                 room.getUsers().forEach(
-                                        user -> fcmService.sendMessageTo(new FcmDto.Request(user.getPushToken(), user.getDeviceOs(),
-                                                "OurMemory - 방 생성", String.format("일정 '%s' 을 공유하기 위한 방 '%s' 가 생성되었습니다.",
-                                                        memory.getName(), room.getName()))));
+                                        user -> fcmService.sendMessageTo(
+                                                FcmDto.Request.builder()
+                                                        .token(user.getPushToken())
+                                                        .deviceOs(user.getDeviceOs())
+                                                        .title("OurMemory - 방 생성")
+                                                        .body(String.format("일정 '%s' 을 공유하기 위한 방 '%s' 가 생성되었습니다.",
+                                                                memory.getName(), room.getName()))
+                                                        .build())
+                                );
+
                                 return room;
                             }).orElseThrow(() -> new MemoryNotFoundRoomException(
-                                    String.format("Unable to find a room to include the memory '%s'. roomId: %d",
-                                            memory.getName(), insertRoomResponseDto.getRoomId())));
+                                            String.format(NOT_FOUND_MESSAGE, "room", insertRoomResponseDto.getRoomId())
+                                    )
+                            );
                         })
                         // If no participants are present
-                        .orElse(null)
-                );
+                        .orElse(null));
 
         return Optional.ofNullable(mainRoom)
                 // If a room exists to associate with the memory
@@ -184,26 +198,47 @@ public class MemoryService {
 
     public FindMemoryDto.Response find(long id) {
         return findMemory(id)
+                .filter(Memory::isUsed)
                 .map(FindMemoryDto.Response::new)
-                .orElseThrow(() -> new MemoryNotFoundException("Not found memory matched to memoryId: " + id));
+                .orElseThrow(() -> new MemoryNotFoundException(
+                                String.format(NOT_FOUND_MESSAGE, "memory", id)
+                        )
+                );
+    }
+
+    public List<FindMemoriesDto.Response> findMemories(Long userId, String name) {
+        List<Memory> findMemories = new ArrayList<>();
+
+        findUser(userId).ifPresent(user -> findMemories.addAll(user.getMemories()));
+        findMemoriesByName(name).ifPresent(findMemories::addAll);
+
+        return findMemories.stream()
+                .filter(Memory::isUsed)
+                .sorted(Comparator.comparing(Memory::getStartDate)) // first order
+                .sorted(Comparator.comparing(Memory::getEndDate))   // second order
+                .map(FindMemoriesDto.Response::new)
+                .collect(Collectors.toList());
+    }
+
+    public UpdateMemoryDto.Response update(long memoryId, UpdateMemoryDto.Request request) {
+        return findMemory(memoryId).map(memory ->
+                memory.updateMemory(request)
+                .map(r -> new UpdateMemoryDto.Response(r.formatModDate()))
+                .orElseThrow(() -> new MemoryInternalServerException("Failed to update for memory data"))
+        )
+        .orElseThrow(
+                () -> new MemoryNotFoundException(String.format(NOT_FOUND_MESSAGE, "memory", memoryId))
+        );
     }
     
-    public List<Memory> findMemories(Long userId) {
-        return findUser(userId)
-                .map(User::getMemories)
-                .orElseThrow(() -> new MemoryNotFoundWriterException("Not found writer from userId: " + userId));
-    }
-    
-    @Transactional
     public DeleteMemoryDto.Response delete(long id) {
         return findMemory(id)
-                .map(memory -> {
-                    memory.getRooms().forEach(room -> room.getMemories().remove(memory));
-                    memory.getUsers().forEach(user -> user.getMemories().remove(memory));
-                    deleteMemory(memory);
-                    return new DeleteMemoryDto.Response(BaseTimeEntity.formatNow());
-                })
-                .orElseThrow(() -> new MemoryNotFoundException("Not found memory matched to memoryId: " + id));
+                .map(Memory::deleteMemory)
+                .map(memory -> new DeleteMemoryDto.Response(BaseTimeEntity.formatNow()))
+                .orElseThrow(() -> new MemoryNotFoundException(
+                                String.format(NOT_FOUND_MESSAGE, "memory", id)
+                        )
+                );
     }
     
     /**
@@ -216,11 +251,11 @@ public class MemoryService {
     private Optional<Memory> findMemory(Long id) {
         return Optional.ofNullable(id).flatMap(memoryRepo::findById);
     }
-    
-    private void deleteMemory(Memory memory) {
-        Optional.ofNullable(memory).ifPresent(memoryRepo::delete);
+
+    private Optional<List<Memory>> findMemoriesByName(String name) {
+        return memoryRepo.findAllByName(name);
     }
-    
+
     /**
      * User Repository
      * 

--- a/OurMemory_Server/src/main/java/com/kds/ourmemory/service/v1/room/RoomService.java
+++ b/OurMemory_Server/src/main/java/com/kds/ourmemory/service/v1/room/RoomService.java
@@ -123,7 +123,7 @@ public class RoomService {
     public DeleteRoomDto.Response delete(long id) {
         return findRoom(id)
                 .map(Room::deleteRoom)
-                .map(r -> new DeleteRoomDto.Response(BaseTimeEntity.formatNow()))
+                .map(room -> new DeleteRoomDto.Response(BaseTimeEntity.formatNow()))
                 .orElseThrow(() -> new RoomNotFoundException(
                                 String.format(NOT_FOUND_MESSAGE, "room", id)
                         )

--- a/OurMemory_Server/src/main/java/com/kds/ourmemory/service/v1/room/RoomService.java
+++ b/OurMemory_Server/src/main/java/com/kds/ourmemory/service/v1/room/RoomService.java
@@ -22,7 +22,8 @@ import javax.transaction.Transactional;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
+
+import static java.util.stream.Collectors.toList;
 
 @RequiredArgsConstructor
 @Service
@@ -98,15 +99,16 @@ public class RoomService {
     }
 
     public List<Room> findRooms(Long userId, String name) {
-        return findUser(userId).map(
-                user -> findRoomsByOwnerOrName(user, name)
-                        .map(List::stream)
-                        .map(stream -> stream.filter(Room::isUsed).collect(Collectors.toList()))
-                        .orElseGet(ArrayList::new)
-        )
-        .orElseThrow(
-                () -> new RoomNotFoundOwnerException(String.format(NOT_FOUND_MESSAGE, "owner", userId))
+        List<Room> findRooms = new ArrayList<>();
+
+        findUser(userId).ifPresent(
+                user -> findRooms.addAll(user.getRooms().stream().filter(Room::isUsed).collect(toList()))
         );
+        findRoomsByName(name).ifPresent(
+                rooms -> findRooms.addAll(rooms.stream().filter(Room::isUsed).collect(toList()))
+        );
+
+        return findRooms;
     }
 
     public UpdateRoomDto.Response update(long roomId, UpdateRoomDto.Request request) {
@@ -123,6 +125,10 @@ public class RoomService {
     public DeleteRoomDto.Response delete(long id) {
         return findRoom(id)
                 .map(Room::deleteRoom)
+                .map(room -> {
+                    room.getMemories().forEach(room::deleteMemory);
+                    return room;
+                })
                 .map(room -> new DeleteRoomDto.Response(BaseTimeEntity.formatNow()))
                 .orElseThrow(() -> new RoomNotFoundException(
                                 String.format(NOT_FOUND_MESSAGE, "room", id)
@@ -141,8 +147,8 @@ public class RoomService {
         return Optional.ofNullable(id).flatMap(roomRepo::findById);
     }
 
-    private Optional<List<Room>> findRoomsByOwnerOrName(User user, String name) {
-        return roomRepo.findAllByOwnerOrName(user, name);
+    private Optional<List<Room>> findRoomsByName(String name) {
+        return roomRepo.findAllByName(name);
     }
 
     /**

--- a/OurMemory_Server/src/test/java/com/kds/ourmemory/controller/v1/memory/MemoryControllerTest.java
+++ b/OurMemory_Server/src/test/java/com/kds/ourmemory/controller/v1/memory/MemoryControllerTest.java
@@ -29,7 +29,7 @@ class MemoryControllerTest {
     @Transactional
     @Test
     void findMemories() throws JsonProcessingException{
-        ApiResult<List<FindMemoriesDto.Response>> responseDto = memoryController.findMemories(99L);
+        ApiResult<List<FindMemoriesDto.Response>> responseDto = memoryController.findMemories(99L, null);
         
         assertThat(responseDto).isNotNull();
         assertThat(responseDto.getResultcode()).isEqualTo("00");

--- a/OurMemory_Server/src/test/java/com/kds/ourmemory/service/v1/friend/FriendServiceTest.java
+++ b/OurMemory_Server/src/test/java/com/kds/ourmemory/service/v1/friend/FriendServiceTest.java
@@ -98,10 +98,6 @@ class FriendServiceTest {
         RequestFriendDto.Request requestReq = new RequestFriendDto.Request(user.getId(), friend.getId());
         AcceptFriendDto.Request acceptReq = new AcceptFriendDto.Request(friend.getId(), user.getId());
 
-        DeleteFriendDto.Request deleteReqFriendFromUser = new DeleteFriendDto.Request(user.getId(), friend.getId());
-        DeleteFriendDto.Request deleteReqUserFromFriend = new DeleteFriendDto.Request(friend.getId(), user.getId());
-
-
         /* 1. Request friend */
         RequestFriendDto.Response requestRsp = friendService.requestFriend(requestReq);
         assertThat(requestRsp).isNotNull();
@@ -117,16 +113,16 @@ class FriendServiceTest {
         assertThat(responseList).isNotNull();
         assertThat(!responseList.isEmpty()).isTrue();
         Friend findFriend = responseList.get(0);
-        assertThat(findFriend.getFriend()).isEqualTo(friend);
+        assertThat(findFriend.getFriendUser()).isEqualTo(friend);
 
         responseList = friendService.findFriends(friend.getId());
         assertThat(responseList).isNotNull();
         assertThat(!responseList.isEmpty()).isTrue();
-        assertThat(responseList.get(0).getFriend().getId()).isEqualTo(user.getId());
+        assertThat(responseList.get(0).getFriendUser().getId()).isEqualTo(user.getId());
 
         /* 3. Delete friend */
         // Delete friend from user
-        DeleteFriendDto.Response mySideDeleteRsp = friendService.deleteFriend(deleteReqFriendFromUser);
+        DeleteFriendDto.Response mySideDeleteRsp = friendService.deleteFriend(user.getId(), friend.getId());
         assertThat(mySideDeleteRsp).isNotNull();
         assertThat(isNow(mySideDeleteRsp.getDeleteDate())).isTrue();
 
@@ -138,10 +134,10 @@ class FriendServiceTest {
         List<Friend> friendSideFriends = friendService.findFriends(friend.getId());
         assertThat(friendSideFriends.size()).isEqualTo(1);
         Friend friendSideFriend = friendSideFriends.get(0);
-        assertThat(friendSideFriend.getFriend().getId()).isEqualTo(user.getId());
+        assertThat(friendSideFriend.getFriendUser().getId()).isEqualTo(user.getId());
 
         // Delete user from friend
-        DeleteFriendDto.Response friendSideDeleteRsp = friendService.deleteFriend(deleteReqUserFromFriend);
+        DeleteFriendDto.Response friendSideDeleteRsp = friendService.deleteFriend(friend.getId(), user.getId());
         assertThat(friendSideDeleteRsp).isNotNull();
         assertThat(isNow(friendSideDeleteRsp.getDeleteDate())).isTrue();
 
@@ -190,9 +186,6 @@ class FriendServiceTest {
         AcceptFriendDto.Request acceptReq = new AcceptFriendDto.Request(friend.getId(), user.getId());
         ReAddFriendDto.Request addReq = new ReAddFriendDto.Request(user.getId(), friend.getId());
 
-        DeleteFriendDto.Request deleteReqFriendFromUser = new DeleteFriendDto.Request(user.getId(), friend.getId());
-        DeleteFriendDto.Request deleteReqUserFromFriend = new DeleteFriendDto.Request(friend.getId(), user.getId());
-
         /* 0-3. Request friend for other side friend */
         RequestFriendDto.Response beforeRequestRsp = friendService.requestFriend(requestReq);
         assertThat(beforeRequestRsp).isNotNull();
@@ -205,7 +198,7 @@ class FriendServiceTest {
 
         /* 0-5. Delete friend from my side */
         // Delete friend from user
-        DeleteFriendDto.Response beforeMySideDeleteRsp = friendService.deleteFriend(deleteReqFriendFromUser);
+        DeleteFriendDto.Response beforeMySideDeleteRsp = friendService.deleteFriend(user.getId(), friend.getId());
         assertThat(beforeMySideDeleteRsp).isNotNull();
         assertThat(isNow(beforeMySideDeleteRsp.getDeleteDate())).isTrue();
 
@@ -217,7 +210,7 @@ class FriendServiceTest {
         List<Friend> beforeFriendSideFriends = friendService.findFriends(friend.getId());
         assertThat(beforeFriendSideFriends.size()).isEqualTo(1);
         Friend beforeFriendSideFriend = beforeFriendSideFriends.get(0);
-        assertThat(beforeFriendSideFriend.getFriend().getId()).isEqualTo(user.getId());
+        assertThat(beforeFriendSideFriend.getFriendUser().getId()).isEqualTo(user.getId());
 
 
         /* 1. Request friend */
@@ -240,16 +233,16 @@ class FriendServiceTest {
         assertThat(responseList).isNotNull();
         assertThat(!responseList.isEmpty()).isTrue();
         Friend findFriend = responseList.get(0);
-        assertThat(findFriend.getFriend()).isEqualTo(friend);
+        assertThat(findFriend.getFriendUser()).isEqualTo(friend);
 
         responseList = friendService.findFriends(friend.getId());
         assertThat(responseList).isNotNull();
         assertThat(!responseList.isEmpty()).isTrue();
-        assertThat(responseList.get(0).getFriend().getId()).isEqualTo(user.getId());
+        assertThat(responseList.get(0).getFriendUser().getId()).isEqualTo(user.getId());
 
         /* 5. Delete friend */
         // Delete friend from user
-        DeleteFriendDto.Response mySideDeleteRsp = friendService.deleteFriend(deleteReqFriendFromUser);
+        DeleteFriendDto.Response mySideDeleteRsp = friendService.deleteFriend(user.getId(), friend.getId());
         assertThat(mySideDeleteRsp).isNotNull();
         assertThat(isNow(mySideDeleteRsp.getDeleteDate())).isTrue();
 
@@ -261,10 +254,10 @@ class FriendServiceTest {
         List<Friend> friendSideFriends = friendService.findFriends(friend.getId());
         assertThat(friendSideFriends.size()).isEqualTo(1);
         Friend friendSideFriend = friendSideFriends.get(0);
-        assertThat(friendSideFriend.getFriend().getId()).isEqualTo(user.getId());
+        assertThat(friendSideFriend.getFriendUser().getId()).isEqualTo(user.getId());
 
         // Delete user from friend
-        DeleteFriendDto.Response friendSideDeleteRsp = friendService.deleteFriend(deleteReqUserFromFriend);
+        DeleteFriendDto.Response friendSideDeleteRsp = friendService.deleteFriend(friend.getId(), user.getId());
         assertThat(friendSideDeleteRsp).isNotNull();
         assertThat(isNow(friendSideDeleteRsp.getDeleteDate())).isTrue();
 
@@ -315,9 +308,6 @@ class FriendServiceTest {
         PatchFriendStatusDto.Request blockReq = new PatchFriendStatusDto.Request(friend.getId(), user.getId(), FriendStatus.BLOCK);
         CancelFriendDto.Request cancelReq = new CancelFriendDto.Request(user.getId(), friend.getId());
 
-        DeleteFriendDto.Request deleteReqFriendFromUser = new DeleteFriendDto.Request(user.getId(), friend.getId());
-        DeleteFriendDto.Request deleteReqUserFromFriend = new DeleteFriendDto.Request(friend.getId(), user.getId());
-
         /* 0-3. Request friend for other side friend */
         RequestFriendDto.Response beforeRequestRsp = friendService.requestFriend(requestReq);
         assertThat(beforeRequestRsp).isNotNull();
@@ -330,7 +320,7 @@ class FriendServiceTest {
 
         /* 0-5. Delete friend from my side */
         // Delete friend from user
-        DeleteFriendDto.Response beforeMySideDeleteRsp = friendService.deleteFriend(deleteReqFriendFromUser);
+        DeleteFriendDto.Response beforeMySideDeleteRsp = friendService.deleteFriend(user.getId(), friend.getId());
         assertThat(beforeMySideDeleteRsp).isNotNull();
         assertThat(isNow(beforeMySideDeleteRsp.getDeleteDate())).isTrue();
 
@@ -342,7 +332,7 @@ class FriendServiceTest {
         List<Friend> beforeFriendSideFriends = friendService.findFriends(friend.getId());
         assertThat(beforeFriendSideFriends.size()).isEqualTo(1);
         Friend beforeFriendSideFriend = beforeFriendSideFriends.get(0);
-        assertThat(beforeFriendSideFriend.getFriend().getId()).isEqualTo(user.getId());
+        assertThat(beforeFriendSideFriend.getFriendUser().getId()).isEqualTo(user.getId());
 
         /* 0-6. Block friend from friend side */
         PatchFriendStatusDto.Response beforeFriendSideBlockRsp = friendService.patchFriendStatus(blockReq);
@@ -375,12 +365,14 @@ class FriendServiceTest {
         assertThat(!responseList.isEmpty()).isTrue();
         Friend findFriend = responseList.get(0);
         assertThat(findFriend.getStatus()).isEqualTo(FriendStatus.BLOCK);
-        assertThat(findFriend.getFriend()).isEqualTo(user);
+        assertThat(findFriend.getFriendUser()).isEqualTo(user);
 
         /* 5. Delete friend */
         // Delete friend from user
+        Long userId = user.getId();
+        Long friendId = friend.getId();
         assertThrows(
-                FriendInternalServerException.class, () -> friendService.deleteFriend(deleteReqFriendFromUser)
+                FriendInternalServerException.class, () -> friendService.deleteFriend(userId, friendId)
         );
 
         // Cancel friend request
@@ -396,11 +388,11 @@ class FriendServiceTest {
         List<Friend> friendSideFriends = friendService.findFriends(friend.getId());
         assertThat(friendSideFriends.size()).isEqualTo(1);
         findFriend = friendSideFriends.get(0);
-        assertThat(findFriend.getFriend()).isEqualTo(user);
+        assertThat(findFriend.getFriendUser()).isEqualTo(user);
         assertThat(findFriend.getStatus()).isEqualTo(FriendStatus.BLOCK);
 
         // Delete user from friend
-        DeleteFriendDto.Response friendSideDeleteRsp = friendService.deleteFriend(deleteReqUserFromFriend);
+        DeleteFriendDto.Response friendSideDeleteRsp = friendService.deleteFriend(friend.getId(), user.getId());
         assertThat(friendSideDeleteRsp).isNotNull();
         assertThat(isNow(friendSideDeleteRsp.getDeleteDate())).isTrue();
 
@@ -449,9 +441,6 @@ class FriendServiceTest {
         AcceptFriendDto.Request acceptReq = new AcceptFriendDto.Request(friend.getId(), user.getId());
         ReAddFriendDto.Request addReq = new ReAddFriendDto.Request(user.getId(), friend.getId());
 
-        DeleteFriendDto.Request deleteReqFriendFromUser = new DeleteFriendDto.Request(user.getId(), friend.getId());
-        DeleteFriendDto.Request deleteReqUserFromFriend = new DeleteFriendDto.Request(friend.getId(), user.getId());
-
         /* 0-3. Request friend for my side friend */
         RequestFriendDto.Response beforeRequestRsp = friendService.requestFriend(requestReq);
         assertThat(beforeRequestRsp).isNotNull();
@@ -464,7 +453,7 @@ class FriendServiceTest {
 
         /* 0-5. Delete user from friend side */
         // Delete user from friend
-        DeleteFriendDto.Response beforeMySideDeleteRsp = friendService.deleteFriend(deleteReqUserFromFriend);
+        DeleteFriendDto.Response beforeMySideDeleteRsp = friendService.deleteFriend(friend.getId(), user.getId());
         assertThat(beforeMySideDeleteRsp).isNotNull();
         assertThat(isNow(beforeMySideDeleteRsp.getDeleteDate())).isTrue();
 
@@ -497,7 +486,7 @@ class FriendServiceTest {
         assertThat(responseList).isNotNull();
         assertThat(!responseList.isEmpty()).isTrue();
         Friend findFriend = responseList.get(0);
-        assertThat(findFriend.getFriend()).isEqualTo(friend);
+        assertThat(findFriend.getFriendUser()).isEqualTo(friend);
 
         responseList = friendService.findFriends(friend.getId());
         assertThat(responseList).isNotNull();
@@ -505,7 +494,7 @@ class FriendServiceTest {
 
         /* 5. Delete friend */
         // Delete friend from user
-        DeleteFriendDto.Response mySideDeleteRsp = friendService.deleteFriend(deleteReqFriendFromUser);
+        DeleteFriendDto.Response mySideDeleteRsp = friendService.deleteFriend(user.getId(), friend.getId());
         assertThat(mySideDeleteRsp).isNotNull();
         assertThat(isNow(mySideDeleteRsp.getDeleteDate())).isTrue();
 
@@ -518,8 +507,10 @@ class FriendServiceTest {
         assertThat(friendSideFriends.size()).isZero();
 
         // Delete user from friend
+        Long userId = user.getId();
+        Long friendId = friend.getId();
         assertThrows(
-                FriendNotFoundFriendException.class, () -> friendService.deleteFriend(deleteReqUserFromFriend)
+                FriendNotFoundFriendException.class, () -> friendService.deleteFriend(friendId, userId)
         );
 
         // Check my side
@@ -568,9 +559,6 @@ class FriendServiceTest {
         ReAddFriendDto.Request addReq = new ReAddFriendDto.Request(user.getId(), friend.getId());
         PatchFriendStatusDto.Request blockReq = new PatchFriendStatusDto.Request(user.getId(), friend.getId(), FriendStatus.BLOCK);
 
-        DeleteFriendDto.Request deleteReqFriendFromUser = new DeleteFriendDto.Request(user.getId(), friend.getId());
-        DeleteFriendDto.Request deleteReqUserFromFriend = new DeleteFriendDto.Request(friend.getId(), user.getId());
-
         /* 0-3. Request friend for my side friend */
         RequestFriendDto.Response beforeRequestRsp = friendService.requestFriend(requestReq);
         assertThat(beforeRequestRsp).isNotNull();
@@ -583,7 +571,7 @@ class FriendServiceTest {
 
         /* 0-5. Delete user from friend side */
         // Delete user from friend
-        DeleteFriendDto.Response beforeMySideDeleteRsp = friendService.deleteFriend(deleteReqUserFromFriend);
+        DeleteFriendDto.Response beforeMySideDeleteRsp = friendService.deleteFriend(friend.getId(), user.getId());
         assertThat(beforeMySideDeleteRsp).isNotNull();
         assertThat(isNow(beforeMySideDeleteRsp.getDeleteDate())).isTrue();
 
@@ -622,7 +610,7 @@ class FriendServiceTest {
         assertThat(!responseList.isEmpty()).isTrue();
         Friend findFriend = responseList.get(0);
         assertThat(findFriend.getStatus()).isEqualTo(FriendStatus.BLOCK);
-        assertThat(findFriend.getFriend()).isEqualTo(friend);
+        assertThat(findFriend.getFriendUser()).isEqualTo(friend);
 
         responseList = friendService.findFriends(friend.getId());
         assertThat(responseList).isNotNull();
@@ -630,7 +618,7 @@ class FriendServiceTest {
 
         /* 4. Delete friend */
         // Delete friend from user
-        DeleteFriendDto.Response mySideDeleteRsp = friendService.deleteFriend(deleteReqFriendFromUser);
+        DeleteFriendDto.Response mySideDeleteRsp = friendService.deleteFriend(user.getId(), friend.getId());
         assertThat(mySideDeleteRsp).isNotNull();
         assertThat(isNow(mySideDeleteRsp.getDeleteDate())).isTrue();
 
@@ -643,8 +631,10 @@ class FriendServiceTest {
         assertThat(friendSideFriends.size()).isZero();
 
         // Delete user from friend
+        Long userId = user.getId();
+        Long friendId = friend.getId();
         assertThrows(
-                FriendNotFoundFriendException.class, () -> friendService.deleteFriend(deleteReqUserFromFriend)
+                FriendNotFoundFriendException.class, () -> friendService.deleteFriend(friendId, userId)
         );
 
         // Check my side
@@ -691,9 +681,6 @@ class FriendServiceTest {
         RequestFriendDto.Request requestReq = new RequestFriendDto.Request(user.getId(), friend.getId());
         AcceptFriendDto.Request acceptReq = new AcceptFriendDto.Request(friend.getId(), user.getId());
 
-        DeleteFriendDto.Request deleteReqFriendFromUser = new DeleteFriendDto.Request(user.getId(), friend.getId());
-        DeleteFriendDto.Request deleteReqUserFromFriend = new DeleteFriendDto.Request(friend.getId(), user.getId());
-
         /* 0-3. Request friend for my side friend */
         RequestFriendDto.Response beforeRequestRsp = friendService.requestFriend(requestReq);
         assertThat(beforeRequestRsp).isNotNull();
@@ -720,18 +707,18 @@ class FriendServiceTest {
         assertThat(responseList).isNotNull();
         assertThat(!responseList.isEmpty()).isTrue();
         Friend findFriend = responseList.get(0);
-        assertThat(findFriend.getFriend()).isEqualTo(friend);
+        assertThat(findFriend.getFriendUser()).isEqualTo(friend);
 
         responseList = friendService.findFriends(friend.getId());
         assertThat(responseList).isNotNull();
         assertThat(responseList.size()).isEqualTo(1);
         findFriend = responseList.get(0);
-        assertThat(findFriend.getFriend()).isEqualTo(user);
+        assertThat(findFriend.getFriendUser()).isEqualTo(user);
 
 
         /* 4. Delete friend */
         // Delete friend from user
-        DeleteFriendDto.Response mySideDeleteRsp = friendService.deleteFriend(deleteReqFriendFromUser);
+        DeleteFriendDto.Response mySideDeleteRsp = friendService.deleteFriend(user.getId(), friend.getId());
         assertThat(mySideDeleteRsp).isNotNull();
         assertThat(isNow(mySideDeleteRsp.getDeleteDate())).isTrue();
 
@@ -743,10 +730,10 @@ class FriendServiceTest {
         List<Friend> friendSideFriends = friendService.findFriends(friend.getId());
         assertThat(friendSideFriends.size()).isEqualTo(1);
         Friend friendSideFriend = friendSideFriends.get(0);
-        assertThat(friendSideFriend.getFriend().getId()).isEqualTo(user.getId());
+        assertThat(friendSideFriend.getFriendUser().getId()).isEqualTo(user.getId());
 
         // Delete user from friend
-        DeleteFriendDto.Response friendSideDeleteRsp = friendService.deleteFriend(deleteReqUserFromFriend);
+        DeleteFriendDto.Response friendSideDeleteRsp = friendService.deleteFriend(friend.getId(), user.getId());
         assertThat(friendSideDeleteRsp).isNotNull();
         assertThat(isNow(friendSideDeleteRsp.getDeleteDate())).isTrue();
 

--- a/OurMemory_Server/src/test/java/com/kds/ourmemory/service/v1/memory/MemoryServiceTest.java
+++ b/OurMemory_Server/src/test/java/com/kds/ourmemory/service/v1/memory/MemoryServiceTest.java
@@ -1,10 +1,9 @@
 package com.kds.ourmemory.service.v1.memory;
 
-import com.kds.ourmemory.controller.v1.memory.dto.DeleteMemoryDto;
-import com.kds.ourmemory.controller.v1.memory.dto.InsertMemoryDto;
+import com.kds.ourmemory.advice.v1.memory.exception.MemoryNotFoundException;
+import com.kds.ourmemory.controller.v1.memory.dto.*;
 import com.kds.ourmemory.controller.v1.room.dto.InsertRoomDto;
 import com.kds.ourmemory.entity.BaseTimeEntity;
-import com.kds.ourmemory.entity.memory.Memory;
 import com.kds.ourmemory.entity.user.DeviceOs;
 import com.kds.ourmemory.entity.user.User;
 import com.kds.ourmemory.entity.user.UserRole;
@@ -21,8 +20,11 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 
 @Slf4j
@@ -49,11 +51,11 @@ class MemoryServiceTest {
      * ______________________________________________________
      * |main room|          Memory member         |Make room|
      * |====================================================|
-     * |    O    |0 < Memory member <= room member|    X    |
-     * |    O    |0 < Memory member != room member|    O    |
-     * |    O    |      0 == Memory member        |    X    |
-     * |    X    |      0 < Memory member         |    O    |
-     * |    X    |               X                |    X    |
+     * |    O    |0 < Memory member <= room member|    X    |   not yet. Memory.java -> updateColumn() error
+     * |    O    |0 < Memory member != room member|    O    |   not yet.
+     * |    O    |      0 == Memory member        |    X    |   not yet.
+     * |    X    |      0 < Memory member         |    O    |   not yet.
+     * |    X    |               X                |    X    |   not yet.
      * ------------------------------------------------------
      */
 
@@ -73,14 +75,14 @@ class MemoryServiceTest {
     @Test
     @Order(1)
     @Transactional
-    void RoomO_MemberO() {
+    void RoomO_memberO() {
         /* 0-1. Create writer, member */
-        User Creator = userRepo.save(
+        User writer = userRepo.save(
                 User.builder()
-                        .snsId("Creator_snsId")
+                        .snsId("writer_snsId")
                         .snsType(1)
-                        .pushToken("Creator Token")
-                        .name("Creator")
+                        .pushToken("writer Token")
+                        .name("writer")
                         .birthday("0724")
                         .solar(true)
                         .birthdayOpen(true)
@@ -90,12 +92,12 @@ class MemoryServiceTest {
                         .build()
         );
 
-        User Member = userRepo.save(
+        User member = userRepo.save(
                 User.builder()
-                        .snsId("Member_snsId")
+                        .snsId("member_snsId")
                         .snsType(2)
-                        .pushToken("Member Token")
-                        .name("Member")
+                        .pushToken("member Token")
+                        .name("member")
                         .birthday("0519")
                         .solar(true)
                         .birthdayOpen(true)
@@ -105,12 +107,12 @@ class MemoryServiceTest {
                         .build()
         );
 
-        User Member_IncludeX = userRepo.save(
+        User member_IncludeX = userRepo.save(
                 User.builder()
-                        .snsId("Member_IncludeX_snsId")
+                        .snsId("member_IncludeX_snsId")
                         .snsType(2)
-                        .pushToken("Member_IncludeX Token")
-                        .name("Member_IncludeX")
+                        .pushToken("member_IncludeX Token")
+                        .name("member_IncludeX")
                         .birthday("0807")
                         .solar(true)
                         .birthdayOpen(true)
@@ -121,25 +123,23 @@ class MemoryServiceTest {
         );
         
         /* 0-2. Make main room, share room */
-        List<Long> mainRoom_Member = new ArrayList<>();
-        mainRoom_Member.add(Member.getId());
-        InsertRoomDto.Response mainRoom = roomService.insert(new InsertRoomDto.Request("mainRoom", Creator.getId(), false, mainRoom_Member));
-        InsertRoomDto.Response shareRoom1 = roomService.insert(new InsertRoomDto.Request("shareRoom1", Member.getId(), false, mainRoom_Member));
-        InsertRoomDto.Response shareRoom2 = roomService.insert(new InsertRoomDto.Request("shareRoom2", Member_IncludeX.getId(), false, mainRoom_Member));
+        List<Long> mainRoom_member = new ArrayList<>();
+        mainRoom_member.add(member.getId());
+        InsertRoomDto.Response mainRoom = roomService.insert(new InsertRoomDto.Request("mainRoom", writer.getId(), false, mainRoom_member));
+        InsertRoomDto.Response shareRoom1 = roomService.insert(new InsertRoomDto.Request("shareRoom1", member.getId(), false, mainRoom_member));
+        InsertRoomDto.Response shareRoom2 = roomService.insert(new InsertRoomDto.Request("shareRoom2", member_IncludeX.getId(), false, mainRoom_member));
         
         List<Long> shareRooms = new ArrayList<>();
         shareRooms.add(shareRoom1.getRoomId());
         shareRooms.add(shareRoom2.getRoomId());
         
         /* 0-3. Create request */
-        List<Long> member = new ArrayList<>();
-        member.add(Member.getId());
         InsertMemoryDto.Request insertReq = new InsertMemoryDto.Request(
-                Creator.getId(),
+                writer.getId(),
                 mainRoom.getRoomId(),
                 "Test Memory",
-                member,
-                "Test Contents", 
+                Stream.of(member.getId()).collect(Collectors.toList()),
+                "Test Contents",
                 "Test Place", 
                 LocalDateTime.parse("2022-03-26 17:00", alertTimeFormat), // 시작 시간 
                 LocalDateTime.parse("2022-03-26 18:00", alertTimeFormat), // 종료 시간
@@ -148,43 +148,80 @@ class MemoryServiceTest {
                 "#FFFFFF",  // 배경색
                 shareRooms     // 공유할 Room
                 );
+
+        UpdateMemoryDto.Request updateReq = new UpdateMemoryDto.Request(
+                "Update memory name",
+                null,
+                "Update contents",
+                "Update place",
+                LocalDateTime.parse("2021-07-08 17:00", alertTimeFormat),
+                LocalDateTime.parse("2021-07-09 17:00", alertTimeFormat),
+                null,
+                null,
+                null
+        );
         
-        /* 1. Make memory */
+        /* 1. Insert */
         InsertMemoryDto.Response insertRsp = memoryService.insert(insertReq);
         assertThat(insertRsp).isNotNull();
-        assertThat(isNow(insertRsp.getAddDate())).isTrue();
-        assertThat(insertRsp.getRoomId()).isEqualTo(insertReq.getRoomId());
+        assertThat(insertRsp.getWriterId()).isEqualTo(writer.getId());
+        assertThat(insertRsp.getMainRoomId()).isEqualTo(insertReq.getRoomId());
         
-        log.info("[RoomO_MemberO] CreateDate: {} memoryId: {}, roomId: {}", insertRsp.getAddDate(),
-                insertRsp.getMemoryId(), insertRsp.getRoomId());
+        /* 2. Find memories */
+        List<FindMemoriesDto.Response> findMemoriesList = memoryService.findMemories(insertReq.getUserId(), null);
+        assertThat(findMemoriesList).isNotNull();
+
+        findMemoriesList = memoryService.findMemories(null, "Test Memory");
+        assertThat(findMemoriesList).isNotNull();
+
+        FindMemoriesDto.Response findMemoriesRsp = findMemoriesList.get(0);
+        assertThat(findMemoriesRsp).isNotNull();
+        assertThat(findMemoriesRsp.getMemoryId()).isEqualTo(insertRsp.getMemoryId());
         
-        
-        /* 2. Find memory */
-        List<Memory> responseList = memoryService.findMemories(insertReq.getUserId());
-        assertThat(responseList).isNotNull();
-        
-        log.info("[RoomO_MemberO_Memory_Read]");
-        responseList.forEach(memory -> log.info(memory.toString()));
-        log.info("====================================================================================");
-        
-        /* 3. Delete memory */
+        log.info("[RoomO_memberO_Memory_Read] Find memories");
+        findMemoriesList.forEach(memory -> log.info(memory.toString()));
+
+        /* 3. Find before update */
+        FindMemoryDto.Response beforeFindRsp = memoryService.find(insertRsp.getMemoryId());
+        assertThat(beforeFindRsp).isNotNull();
+        assertThat(beforeFindRsp.getName()).isEqualTo(insertRsp.getName());
+        assertThat(beforeFindRsp.getContents()).isEqualTo(insertRsp.getContents());
+
+        /* 4. Update */
+        UpdateMemoryDto.Response updateRsp = memoryService.update(insertRsp.getMemoryId(), updateReq);
+        assertThat(updateRsp).isNotNull();
+        assertThat(isNow(updateRsp.getUpdateDate())).isTrue();
+
+        /* 5. Find after update */
+        FindMemoryDto.Response afterFindRsp = memoryService.find(insertRsp.getMemoryId());
+        assertThat(afterFindRsp).isNotNull();
+        assertThat(afterFindRsp.getName()).isEqualTo(updateReq.getName());
+        assertThat(afterFindRsp.getContents()).isEqualTo(updateReq.getContents());
+
+        /* 6. Delete */
         DeleteMemoryDto.Response deleteRsp = memoryService.delete(insertRsp.getMemoryId());
-        
         assertThat(deleteRsp).isNotNull();
         assertThat(isNow(deleteRsp.getDeleteDate())).isTrue();
+
+        /* 7. Find after delete */
+        Long memoryId = insertRsp.getMemoryId();
+        assertThat(memoryId).isNotNull();
+        assertThrows(
+                MemoryNotFoundException.class, () -> memoryService.find(memoryId)
+        );
     }
     
     @Test
     @Order(2)
     @Transactional
-    void RoomO_MemberO_IncludeX_Memory() {
+    void RoomO_memberO_IncludeX_Memory() {
         /* 0-1. Create writer, member */
-        User Creator = userRepo.save(
+        User writer = userRepo.save(
                 User.builder()
-                        .snsId("Creator_snsId")
+                        .snsId("writer_snsId")
                         .snsType(1)
-                        .pushToken("Creator Token")
-                        .name("Creator")
+                        .pushToken("writer Token")
+                        .name("writer")
                         .birthday("0724")
                         .solar(true)
                         .birthdayOpen(true)
@@ -194,12 +231,12 @@ class MemoryServiceTest {
                         .build()
         );
 
-        User Member = userRepo.save(
+        User member = userRepo.save(
                 User.builder()
-                        .snsId("Member_snsId")
+                        .snsId("member_snsId")
                         .snsType(2)
-                        .pushToken("Member Token")
-                        .name("Member")
+                        .pushToken("member Token")
+                        .name("member")
                         .birthday("0519")
                         .solar(true)
                         .birthdayOpen(true)
@@ -209,12 +246,12 @@ class MemoryServiceTest {
                         .build()
         );
 
-        User Member_IncludeX = userRepo.save(
+        User member_IncludeX = userRepo.save(
                 User.builder()
-                        .snsId("Member_IncludeX_snsId")
+                        .snsId("member_IncludeX_snsId")
                         .snsType(2)
-                        .pushToken("Member_IncludeX Token")
-                        .name("Member_IncludeX")
+                        .pushToken("member_IncludeX Token")
+                        .name("member_IncludeX")
                         .birthday("0807")
                         .solar(true)
                         .birthdayOpen(true)
@@ -225,24 +262,22 @@ class MemoryServiceTest {
         );
         
         /* 0-2. Make main room, share room */
-        List<Long> mainRoom_Member = new ArrayList<>();
-        mainRoom_Member.add(Member.getId());
-        InsertRoomDto.Response mainRoom = roomService.insert(new InsertRoomDto.Request("mainRoom", Creator.getId(), false, mainRoom_Member));
-        InsertRoomDto.Response shareRoom1 = roomService.insert(new InsertRoomDto.Request("shareRoom1", Member.getId(), false, mainRoom_Member));
-        InsertRoomDto.Response shareRoom2 = roomService.insert(new InsertRoomDto.Request("shareRoom2", Member_IncludeX.getId(), false, mainRoom_Member));
+        List<Long> mainRoom_member = new ArrayList<>();
+        mainRoom_member.add(member.getId());
+        InsertRoomDto.Response mainRoom = roomService.insert(new InsertRoomDto.Request("mainRoom", writer.getId(), false, mainRoom_member));
+        InsertRoomDto.Response shareRoom1 = roomService.insert(new InsertRoomDto.Request("shareRoom1", member.getId(), false, mainRoom_member));
+        InsertRoomDto.Response shareRoom2 = roomService.insert(new InsertRoomDto.Request("shareRoom2", member_IncludeX.getId(), false, mainRoom_member));
         
         List<Long> shareRooms = new ArrayList<>();
         shareRooms.add(shareRoom1.getRoomId());
         shareRooms.add(shareRoom2.getRoomId());
         
         /* 0-3. Create request */
-        List<Long> member = new ArrayList<>();
-        member.add(Member_IncludeX.getId());
         InsertMemoryDto.Request insertReq = new InsertMemoryDto.Request(
-                Creator.getId(),
+                writer.getId(),
                 mainRoom.getRoomId(),
                 "Test Memory",
-                member,
+                Stream.of(member_IncludeX.getId()).collect(Collectors.toList()),
                 "Test Contents", 
                 "Test Place", 
                 LocalDateTime.parse("2022-03-26 17:00", alertTimeFormat), // 시작 시간 
@@ -256,38 +291,48 @@ class MemoryServiceTest {
         /* 1. Make memory */
         InsertMemoryDto.Response insertRsp = memoryService.insert(insertReq);
         assertThat(insertRsp).isNotNull();
-        assertThat(isNow(insertRsp.getAddDate())).isTrue();
-        assertThat(insertRsp.getRoomId()).isNotEqualTo(insertReq.getRoomId());
+        assertThat(insertRsp.getWriterId()).isEqualTo(writer.getId());
+        assertThat(insertRsp.getMainRoomId()).isNotEqualTo(insertReq.getRoomId());
+
+        /* 2. Find memories */
+        List<FindMemoriesDto.Response> findMemoriesList = memoryService.findMemories(insertReq.getUserId(), null);
+        assertThat(findMemoriesList).isNotNull();
+
+        findMemoriesList = memoryService.findMemories(null, "Test Memory");
+        assertThat(findMemoriesList).isNotNull();
+
+        FindMemoriesDto.Response findMemoriesRsp = findMemoriesList.get(0);
+        assertThat(findMemoriesRsp).isNotNull();
+        assertThat(findMemoriesRsp.getMemoryId()).isEqualTo(insertRsp.getMemoryId());
         
-        log.info("[RoomO_MemberO_IncludeX] CreateDate: {}, memoryId: {}, roomId: {}", insertRsp.getAddDate(),
-                insertRsp.getMemoryId(), insertRsp.getRoomId());
-        
-        /* 2. Find memory */
-        List<Memory> responseList = memoryService.findMemories(insertReq.getUserId());
-        assertThat(responseList).isNotNull();
-        
-        log.info("[RoomO_MemberO_IncludeX_Memory_Read]");
-        responseList.forEach(memory -> log.info(memory.toString()));
+        log.info("[RoomO_memberO_IncludeX_Memory_Read]");
+        findMemoriesList.forEach(memory -> log.info(memory.toString()));
         log.info("====================================================================================");
-        
+
         /* 3. Delete memory */
         DeleteMemoryDto.Response deleteRsp = memoryService.delete(insertRsp.getMemoryId());
-        
         assertThat(deleteRsp).isNotNull();
         assertThat(isNow(deleteRsp.getDeleteDate())).isTrue();
+
+        /* 4. Find after delete */
+        Long memoryId = insertRsp.getMemoryId();
+        assertThat(memoryId).isNotNull();
+        assertThrows(
+                MemoryNotFoundException.class, () -> memoryService.find(memoryId)
+        );
     }
     
     @Test
     @Order(3)
     @Transactional
-    void RoomO_MemberX_Memory() {
+    void RoomO_memberX_Memory() {
         /* 0-1. Create writer, member */
-        User Creator = userRepo.save(
+        User writer = userRepo.save(
                 User.builder()
-                        .snsId("Creator_snsId")
+                        .snsId("writer_snsId")
                         .snsType(1)
-                        .pushToken("Creator Token")
-                        .name("Creator")
+                        .pushToken("writer Token")
+                        .name("writer")
                         .birthday("0724")
                         .solar(true)
                         .birthdayOpen(true)
@@ -297,12 +342,12 @@ class MemoryServiceTest {
                         .build()
         );
 
-        User Member = userRepo.save(
+        User member = userRepo.save(
                 User.builder()
-                        .snsId("Member_snsId")
+                        .snsId("member_snsId")
                         .snsType(2)
-                        .pushToken("Member Token")
-                        .name("Member")
+                        .pushToken("member Token")
+                        .name("member")
                         .birthday("0519")
                         .solar(true)
                         .birthdayOpen(true)
@@ -312,12 +357,12 @@ class MemoryServiceTest {
                         .build()
         );
 
-        User Member_IncludeX = userRepo.save(
+        User member_IncludeX = userRepo.save(
                 User.builder()
-                        .snsId("Member_IncludeX_snsId")
+                        .snsId("member_IncludeX_snsId")
                         .snsType(2)
-                        .pushToken("Member_IncludeX Token")
-                        .name("Member_IncludeX")
+                        .pushToken("member_IncludeX Token")
+                        .name("member_IncludeX")
                         .birthday("0807")
                         .solar(true)
                         .birthdayOpen(true)
@@ -328,11 +373,11 @@ class MemoryServiceTest {
         );
         
         /* 0-2. Make main room, share room */
-        List<Long> mainRoom_Member = new ArrayList<>();
-        mainRoom_Member.add(Member.getId());
-        InsertRoomDto.Response mainRoom = roomService.insert(new InsertRoomDto.Request("mainRoom", Creator.getId(), false, mainRoom_Member));
-        InsertRoomDto.Response shareRoom1 = roomService.insert(new InsertRoomDto.Request("shareRoom1", Member.getId(), false, mainRoom_Member));
-        InsertRoomDto.Response shareRoom2 = roomService.insert(new InsertRoomDto.Request("shareRoom2", Member_IncludeX.getId(), false, mainRoom_Member));
+        List<Long> mainRoom_member = new ArrayList<>();
+        mainRoom_member.add(member.getId());
+        InsertRoomDto.Response mainRoom = roomService.insert(new InsertRoomDto.Request("mainRoom", writer.getId(), false, mainRoom_member));
+        InsertRoomDto.Response shareRoom1 = roomService.insert(new InsertRoomDto.Request("shareRoom1", member.getId(), false, mainRoom_member));
+        InsertRoomDto.Response shareRoom2 = roomService.insert(new InsertRoomDto.Request("shareRoom2", member_IncludeX.getId(), false, mainRoom_member));
         
         List<Long> shareRooms = new ArrayList<>();
         shareRooms.add(shareRoom1.getRoomId());
@@ -340,7 +385,7 @@ class MemoryServiceTest {
         
         /* 0-3. Create request */
         InsertMemoryDto.Request insertReq = new InsertMemoryDto.Request(
-                Creator.getId(),
+                writer.getId(),
                 mainRoom.getRoomId(),
                 "Test Memory",
                 null,
@@ -357,38 +402,48 @@ class MemoryServiceTest {
         /* 1. Make memory */
         InsertMemoryDto.Response insertRsp = memoryService.insert(insertReq);
         assertThat(insertRsp).isNotNull();
-        assertThat(isNow(insertRsp.getAddDate())).isTrue();
-        assertThat(insertRsp.getRoomId()).isEqualTo(insertRsp.getRoomId());
+        assertThat(insertRsp.getWriterId()).isEqualTo(writer.getId());
+        assertThat(insertRsp.getMainRoomId()).isEqualTo(insertRsp.getMainRoomId());
+
+        /* 2. Find memories */
+        List<FindMemoriesDto.Response> findMemoriesList = memoryService.findMemories(insertReq.getUserId(), null);
+        assertThat(findMemoriesList).isNotNull();
+
+        findMemoriesList = memoryService.findMemories(null, "Test Memory");
+        assertThat(findMemoriesList).isNotNull();
+
+        FindMemoriesDto.Response findMemoriesRsp = findMemoriesList.get(0);
+        assertThat(findMemoriesRsp).isNotNull();
+        assertThat(findMemoriesRsp.getMemoryId()).isEqualTo(insertRsp.getMemoryId());
         
-        log.info("[RoomO_MemberX] CreateDate: {} memoryId: {}, roomId: {}", insertRsp.getAddDate(),
-                insertRsp.getMemoryId(), insertRsp.getRoomId());
-        
-        /* 2. Find memory */
-        List<Memory> responseList = memoryService.findMemories(insertReq.getUserId());
-        assertThat(responseList).isNotNull();
-        
-        log.info("[RoomO_MemberX_Memory_Read]");
-        responseList.forEach(memory -> log.info(memory.toString()));
+        log.info("[RoomO_memberX_Memory_Read]");
+        findMemoriesList.forEach(memory -> log.info(memory.toString()));
         log.info("====================================================================================");
         
         /* 3. Delete memory */
         DeleteMemoryDto.Response deleteRsp = memoryService.delete(insertRsp.getMemoryId());
-        
         assertThat(deleteRsp).isNotNull();
         assertThat(isNow(deleteRsp.getDeleteDate())).isTrue();
+
+        /* 4. Find after delete */
+        Long memoryId = insertRsp.getMemoryId();
+        assertThat(memoryId).isNotNull();
+        assertThrows(
+                MemoryNotFoundException.class, () -> memoryService.find(memoryId)
+        );
     }
     
     @Test
     @Order(4)
     @Transactional
-    void RoomX_MemberO_Memory() {
+    void RoomX_memberO_Memory() {
         /* 0-1. Create writer, member */
-        User Creator = userRepo.save(
+        User writer = userRepo.save(
                 User.builder()
-                        .snsId("Creator_snsId")
+                        .snsId("writer_snsId")
                         .snsType(1)
-                        .pushToken("Creator Token")
-                        .name("Creator")
+                        .pushToken("writer Token")
+                        .name("writer")
                         .birthday("0724")
                         .solar(true)
                         .birthdayOpen(true)
@@ -398,12 +453,12 @@ class MemoryServiceTest {
                         .build()
         );
 
-        User Member = userRepo.save(
+        User member = userRepo.save(
                 User.builder()
-                        .snsId("Member_snsId")
+                        .snsId("member_snsId")
                         .snsType(2)
-                        .pushToken("Member Token")
-                        .name("Member")
+                        .pushToken("member Token")
+                        .name("member")
                         .birthday("0519")
                         .solar(true)
                         .birthdayOpen(true)
@@ -413,12 +468,12 @@ class MemoryServiceTest {
                         .build()
         );
 
-        User Member_IncludeX = userRepo.save(
+        User member_IncludeX = userRepo.save(
                 User.builder()
-                        .snsId("Member_IncludeX_snsId")
+                        .snsId("member_IncludeX_snsId")
                         .snsType(2)
-                        .pushToken("Member_IncludeX Token")
-                        .name("Member_IncludeX")
+                        .pushToken("member_IncludeX Token")
+                        .name("member_IncludeX")
                         .birthday("0807")
                         .solar(true)
                         .birthdayOpen(true)
@@ -429,23 +484,21 @@ class MemoryServiceTest {
         );
         
         /* 0-2. Make main room, share room */
-        List<Long> mainRoom_Member = new ArrayList<>();
-        mainRoom_Member.add(Member.getId());
-        InsertRoomDto.Response shareRoom1 = roomService.insert(new InsertRoomDto.Request("shareRoom1", Member.getId(), false, mainRoom_Member));
-        InsertRoomDto.Response shareRoom2 = roomService.insert(new InsertRoomDto.Request("shareRoom2", Member_IncludeX.getId(), false, mainRoom_Member));
+        List<Long> mainRoom_member = new ArrayList<>();
+        mainRoom_member.add(member.getId());
+        InsertRoomDto.Response shareRoom1 = roomService.insert(new InsertRoomDto.Request("shareRoom1", member.getId(), false, mainRoom_member));
+        InsertRoomDto.Response shareRoom2 = roomService.insert(new InsertRoomDto.Request("shareRoom2", member_IncludeX.getId(), false, mainRoom_member));
         
         List<Long> shareRooms = new ArrayList<>();
         shareRooms.add(shareRoom1.getRoomId());
         shareRooms.add(shareRoom2.getRoomId());
         
         /* 0-3. Create request */
-        List<Long> member = new ArrayList<>();
-        member.add(Member.getId());
         InsertMemoryDto.Request insertReq = new InsertMemoryDto.Request(
-                Creator.getId(),
+                writer.getId(),
                 null,
                 "Test Memory",
-                member,
+                Stream.of(member.getId()).collect(Collectors.toList()),
                 "Test Contents", 
                 "Test Place", 
                 LocalDateTime.parse("2022-03-26 17:00", alertTimeFormat), // 시작 시간 
@@ -455,42 +508,52 @@ class MemoryServiceTest {
                 "#FFFFFF",  // 배경색
                 shareRooms     // 공유할 Room
                 );
-        
+
         /* 1. Make memory */
         InsertMemoryDto.Response insertRsp = memoryService.insert(insertReq);
         assertThat(insertRsp).isNotNull();
-        assertThat(isNow(insertRsp.getAddDate())).isTrue();
-        assertThat(insertRsp.getRoomId()).isNotEqualTo(insertReq.getRoomId());
-        
-        log.info("[RoomX_MemberO] CreateDate: {}, memoryId: {}, roomId: {}", insertRsp.getAddDate(),
-                insertRsp.getMemoryId(), insertRsp.getRoomId());
-        
+        assertThat(insertRsp.getWriterId()).isEqualTo(writer.getId());
+        assertThat(insertRsp.getMainRoomId()).isNotEqualTo(insertReq.getRoomId());
+
         /* 2. Find memory */
-        List<Memory> responseList = memoryService.findMemories(insertReq.getUserId());
-        assertThat(responseList).isNotNull();
+        List<FindMemoriesDto.Response> findMemoriesList = memoryService.findMemories(insertReq.getUserId(), null);
+        assertThat(findMemoriesList).isNotNull();
+
+        findMemoriesList = memoryService.findMemories(null, "Test Memory");
+        assertThat(findMemoriesList).isNotNull();
+
+        FindMemoriesDto.Response findMemoriesRsp = findMemoriesList.get(0);
+        assertThat(findMemoriesRsp).isNotNull();
+        assertThat(findMemoriesRsp.getMemoryId()).isEqualTo(insertRsp.getMemoryId());
         
-        log.info("[RoomX_MemberO_Memory_Read]");
-        responseList.forEach(memory -> log.info(memory.toString()));
+        log.info("[RoomX_memberO_Memory_Read]");
+        findMemoriesList.forEach(memory -> log.info(memory.toString()));
         log.info("====================================================================================");
         
         /* 3. Delete memory */
         DeleteMemoryDto.Response deleteRsp = memoryService.delete(insertRsp.getMemoryId());
-        
         assertThat(deleteRsp).isNotNull();
         assertThat(isNow(deleteRsp.getDeleteDate())).isTrue();
+
+        /* 4. Find after delete */
+        Long memoryId = insertRsp.getMemoryId();
+        assertThat(memoryId).isNotNull();
+        assertThrows(
+                MemoryNotFoundException.class, () -> memoryService.find(memoryId)
+        );
     }
     
     @Test
     @Order(5)
     @Transactional
-    void RoomX_MemberX_Memory() {
+    void RoomX_memberX_Memory() {
         /* 0-1. Create writer, member */
-        User Creator = userRepo.save(
+        User writer = userRepo.save(
                 User.builder()
-                        .snsId("Creator_snsId")
+                        .snsId("writer_snsId")
                         .snsType(1)
-                        .pushToken("Creator Token")
-                        .name("Creator")
+                        .pushToken("writer Token")
+                        .name("writer")
                         .birthday("0724")
                         .solar(true)
                         .birthdayOpen(true)
@@ -500,12 +563,12 @@ class MemoryServiceTest {
                         .build()
         );
 
-        User Member = userRepo.save(
+        User member = userRepo.save(
                 User.builder()
-                        .snsId("Member_snsId")
+                        .snsId("member_snsId")
                         .snsType(2)
-                        .pushToken("Member Token")
-                        .name("Member")
+                        .pushToken("member Token")
+                        .name("member")
                         .birthday("0519")
                         .solar(true)
                         .birthdayOpen(true)
@@ -515,12 +578,12 @@ class MemoryServiceTest {
                         .build()
         );
 
-        User Member_IncludeX = userRepo.save(
+        User member_IncludeX = userRepo.save(
                 User.builder()
-                        .snsId("Member_IncludeX_snsId")
+                        .snsId("member_IncludeX_snsId")
                         .snsType(2)
-                        .pushToken("Member_IncludeX Token")
-                        .name("Member_IncludeX")
+                        .pushToken("member_IncludeX Token")
+                        .name("member_IncludeX")
                         .birthday("0807")
                         .solar(true)
                         .birthdayOpen(true)
@@ -531,10 +594,10 @@ class MemoryServiceTest {
         );
         
         /* 0-2. Make main room, share room */
-        List<Long> mainRoom_Member = new ArrayList<>();
-        mainRoom_Member.add(Member.getId());
-        InsertRoomDto.Response shareRoom1 = roomService.insert(new InsertRoomDto.Request("shareRoom1", Member.getId(), false, mainRoom_Member));
-        InsertRoomDto.Response shareRoom2 = roomService.insert(new InsertRoomDto.Request("shareRoom2", Member_IncludeX.getId(), false, mainRoom_Member));
+        List<Long> mainRoom_member = new ArrayList<>();
+        mainRoom_member.add(member.getId());
+        InsertRoomDto.Response shareRoom1 = roomService.insert(new InsertRoomDto.Request("shareRoom1", member.getId(), false, mainRoom_member));
+        InsertRoomDto.Response shareRoom2 = roomService.insert(new InsertRoomDto.Request("shareRoom2", member_IncludeX.getId(), false, mainRoom_member));
         
         List<Long> shareRooms = new ArrayList<>();
         shareRooms.add(shareRoom1.getRoomId());
@@ -542,7 +605,7 @@ class MemoryServiceTest {
         
         /* 0-3. Create request */
         InsertMemoryDto.Request insertReq = new InsertMemoryDto.Request(
-                Creator.getId(),
+                writer.getId(),
                 null,
                 "Test Memory",
                 null,
@@ -559,25 +622,35 @@ class MemoryServiceTest {
         /* 1. Make memory */
         InsertMemoryDto.Response insertRsp = memoryService.insert(insertReq);
         assertThat(insertRsp).isNotNull();
-        assertThat(isNow(insertRsp.getAddDate())).isTrue();
-        assertThat(insertRsp.getRoomId()).isNull();
+        assertThat(insertRsp.getWriterId()).isEqualTo(writer.getId());
+        assertThat(insertRsp.getMainRoomId()).isNull();
+
+        /* 2. Find memories */
+        List<FindMemoriesDto.Response> findMemoriesList = memoryService.findMemories(insertReq.getUserId(), null);
+        assertThat(findMemoriesList).isNotNull();
+
+        findMemoriesList = memoryService.findMemories(null, "Test Memory");
+        assertThat(findMemoriesList).isNotNull();
+
+        FindMemoriesDto.Response findMemoriesRsp = findMemoriesList.get(0);
+        assertThat(findMemoriesRsp).isNotNull();
+        assertThat(findMemoriesRsp.getMemoryId()).isEqualTo(insertRsp.getMemoryId());
         
-        log.info("[RoomX_MemberX] CreateDate: {} memoryId: {}, roomId: {}", insertRsp.getAddDate(),
-                insertRsp.getMemoryId(), insertRsp.getRoomId());
-        
-        /* 2. Find memory */
-        List<Memory> responseList = memoryService.findMemories(insertReq.getUserId());
-        assertThat(responseList).isNotNull();
-        
-        log.info("[RoomX_MemberX_Memory_Read]");
-        responseList.forEach(memory -> log.info(memory.toString()));
+        log.info("[RoomX_memberX_Memory_Read]");
+        findMemoriesList.forEach(memory -> log.info(memory.toString()));
         log.info("====================================================================================");
         
         /* 3. Delete memory */
         DeleteMemoryDto.Response deleteRsp = memoryService.delete(insertRsp.getMemoryId());
-        
         assertThat(deleteRsp).isNotNull();
         assertThat(isNow(deleteRsp.getDeleteDate())).isTrue();
+
+        /* 4. Find after delete */
+        Long memoryId = insertRsp.getMemoryId();
+        assertThat(memoryId).isNotNull();
+        assertThrows(
+                MemoryNotFoundException.class, () -> memoryService.find(memoryId)
+        );
     }
     
     boolean isNow(String time) {

--- a/OurMemory_Server/src/test/java/com/kds/ourmemory/service/v1/memory/MemoryServiceTest.java
+++ b/OurMemory_Server/src/test/java/com/kds/ourmemory/service/v1/memory/MemoryServiceTest.java
@@ -32,12 +32,11 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class MemoryServiceTest {
-
     private final MemoryService memoryService;
-    
-    private final UserRepository userRepo; // Add to work with user data
     private final RoomService roomService; // The creation process from adding to the deletion of the room.
-    
+
+    private final UserRepository userRepo; // Add to work with user data
+
     /**
      * Assert time format -> delete sec
      * 
@@ -51,11 +50,11 @@ class MemoryServiceTest {
      * ______________________________________________________
      * |main room|          Memory member         |Make room|
      * |====================================================|
-     * |    O    |0 < Memory member <= room member|    X    |   not yet. Memory.java -> updateColumn() error
-     * |    O    |0 < Memory member != room member|    O    |   not yet.
-     * |    O    |      0 == Memory member        |    X    |   not yet.
-     * |    X    |      0 < Memory member         |    O    |   not yet.
-     * |    X    |               X                |    X    |   not yet.
+     * |    O    |0 < Memory member <= room member|    X    |
+     * |    O    |0 < Memory member != room member|    O    |
+     * |    O    |      0 == Memory member        |    X    |
+     * |    X    |      0 < Memory member         |    O    |
+     * |    X    |               X                |    X    |
      * ------------------------------------------------------
      */
 
@@ -147,11 +146,10 @@ class MemoryServiceTest {
                 null,       // 두 번째 알림
                 "#FFFFFF",  // 배경색
                 shareRooms     // 공유할 Room
-                );
+        );
 
         UpdateMemoryDto.Request updateReq = new UpdateMemoryDto.Request(
                 "Update memory name",
-                null,
                 "Update contents",
                 "Update place",
                 LocalDateTime.parse("2021-07-08 17:00", alertTimeFormat),
@@ -214,7 +212,7 @@ class MemoryServiceTest {
     @Test
     @Order(2)
     @Transactional
-    void RoomO_memberO_IncludeX_Memory() {
+    void RoomO_memberO_IncludeX() {
         /* 0-1. Create writer, member */
         User writer = userRepo.save(
                 User.builder()
@@ -286,7 +284,18 @@ class MemoryServiceTest {
                 null,       // 두 번째 알림
                 "#FFFFFF",  // 배경색
                 shareRooms     // 공유할 Room
-                );
+        );
+
+        UpdateMemoryDto.Request updateReq = new UpdateMemoryDto.Request(
+                "Update memory name",
+                "Update contents",
+                "Update place",
+                LocalDateTime.parse("2021-07-08 17:00", alertTimeFormat),
+                LocalDateTime.parse("2021-07-09 17:00", alertTimeFormat),
+                null,
+                null,
+                null
+        );
         
         /* 1. Make memory */
         InsertMemoryDto.Response insertRsp = memoryService.insert(insertReq);
@@ -307,14 +316,30 @@ class MemoryServiceTest {
         
         log.info("[RoomO_memberO_IncludeX_Memory_Read]");
         findMemoriesList.forEach(memory -> log.info(memory.toString()));
-        log.info("====================================================================================");
 
-        /* 3. Delete memory */
+        /* 3. Find before update */
+        FindMemoryDto.Response beforeFindRsp = memoryService.find(insertRsp.getMemoryId());
+        assertThat(beforeFindRsp).isNotNull();
+        assertThat(beforeFindRsp.getName()).isEqualTo(insertRsp.getName());
+        assertThat(beforeFindRsp.getContents()).isEqualTo(insertRsp.getContents());
+
+        /* 4. Update */
+        UpdateMemoryDto.Response updateRsp = memoryService.update(insertRsp.getMemoryId(), updateReq);
+        assertThat(updateRsp).isNotNull();
+        assertThat(isNow(updateRsp.getUpdateDate())).isTrue();
+
+        /* 5. Find after update */
+        FindMemoryDto.Response afterFindRsp = memoryService.find(insertRsp.getMemoryId());
+        assertThat(afterFindRsp).isNotNull();
+        assertThat(afterFindRsp.getName()).isEqualTo(updateReq.getName());
+        assertThat(afterFindRsp.getContents()).isEqualTo(updateReq.getContents());
+
+        /* 6. Delete memory */
         DeleteMemoryDto.Response deleteRsp = memoryService.delete(insertRsp.getMemoryId());
         assertThat(deleteRsp).isNotNull();
         assertThat(isNow(deleteRsp.getDeleteDate())).isTrue();
 
-        /* 4. Find after delete */
+        /* 7. Find after delete */
         Long memoryId = insertRsp.getMemoryId();
         assertThat(memoryId).isNotNull();
         assertThrows(
@@ -325,7 +350,7 @@ class MemoryServiceTest {
     @Test
     @Order(3)
     @Transactional
-    void RoomO_memberX_Memory() {
+    void RoomO_memberX() {
         /* 0-1. Create writer, member */
         User writer = userRepo.save(
                 User.builder()
@@ -397,7 +422,18 @@ class MemoryServiceTest {
                 null,       // 두 번째 알림
                 "#FFFFFF",  // 배경색
                 shareRooms     // 공유할 Room
-                );
+        );
+
+        UpdateMemoryDto.Request updateReq = new UpdateMemoryDto.Request(
+                "Update memory name",
+                "Update contents",
+                "Update place",
+                LocalDateTime.parse("2021-07-08 17:00", alertTimeFormat),
+                LocalDateTime.parse("2021-07-09 17:00", alertTimeFormat),
+                null,
+                null,
+                null
+        );
         
         /* 1. Make memory */
         InsertMemoryDto.Response insertRsp = memoryService.insert(insertReq);
@@ -418,14 +454,30 @@ class MemoryServiceTest {
         
         log.info("[RoomO_memberX_Memory_Read]");
         findMemoriesList.forEach(memory -> log.info(memory.toString()));
-        log.info("====================================================================================");
-        
-        /* 3. Delete memory */
+
+        /* 3. Find before update */
+        FindMemoryDto.Response beforeFindRsp = memoryService.find(insertRsp.getMemoryId());
+        assertThat(beforeFindRsp).isNotNull();
+        assertThat(beforeFindRsp.getName()).isEqualTo(insertRsp.getName());
+        assertThat(beforeFindRsp.getContents()).isEqualTo(insertRsp.getContents());
+
+        /* 4. Update */
+        UpdateMemoryDto.Response updateRsp = memoryService.update(insertRsp.getMemoryId(), updateReq);
+        assertThat(updateRsp).isNotNull();
+        assertThat(isNow(updateRsp.getUpdateDate())).isTrue();
+
+        /* 5. Find after update */
+        FindMemoryDto.Response afterFindRsp = memoryService.find(insertRsp.getMemoryId());
+        assertThat(afterFindRsp).isNotNull();
+        assertThat(afterFindRsp.getName()).isEqualTo(updateReq.getName());
+        assertThat(afterFindRsp.getContents()).isEqualTo(updateReq.getContents());
+
+        /* 6. Delete memory */
         DeleteMemoryDto.Response deleteRsp = memoryService.delete(insertRsp.getMemoryId());
         assertThat(deleteRsp).isNotNull();
         assertThat(isNow(deleteRsp.getDeleteDate())).isTrue();
 
-        /* 4. Find after delete */
+        /* 7. Find after delete */
         Long memoryId = insertRsp.getMemoryId();
         assertThat(memoryId).isNotNull();
         assertThrows(
@@ -436,7 +488,7 @@ class MemoryServiceTest {
     @Test
     @Order(4)
     @Transactional
-    void RoomX_memberO_Memory() {
+    void RoomX_memberO() {
         /* 0-1. Create writer, member */
         User writer = userRepo.save(
                 User.builder()
@@ -507,7 +559,18 @@ class MemoryServiceTest {
                 null,       // 두 번째 알림
                 "#FFFFFF",  // 배경색
                 shareRooms     // 공유할 Room
-                );
+        );
+
+        UpdateMemoryDto.Request updateReq = new UpdateMemoryDto.Request(
+                "Update memory name",
+                "Update contents",
+                "Update place",
+                LocalDateTime.parse("2021-07-08 17:00", alertTimeFormat),
+                LocalDateTime.parse("2021-07-09 17:00", alertTimeFormat),
+                null,
+                null,
+                null
+        );
 
         /* 1. Make memory */
         InsertMemoryDto.Response insertRsp = memoryService.insert(insertReq);
@@ -528,14 +591,30 @@ class MemoryServiceTest {
         
         log.info("[RoomX_memberO_Memory_Read]");
         findMemoriesList.forEach(memory -> log.info(memory.toString()));
-        log.info("====================================================================================");
-        
-        /* 3. Delete memory */
+
+        /* 3. Find before update */
+        FindMemoryDto.Response beforeFindRsp = memoryService.find(insertRsp.getMemoryId());
+        assertThat(beforeFindRsp).isNotNull();
+        assertThat(beforeFindRsp.getName()).isEqualTo(insertRsp.getName());
+        assertThat(beforeFindRsp.getContents()).isEqualTo(insertRsp.getContents());
+
+        /* 4. Update */
+        UpdateMemoryDto.Response updateRsp = memoryService.update(insertRsp.getMemoryId(), updateReq);
+        assertThat(updateRsp).isNotNull();
+        assertThat(isNow(updateRsp.getUpdateDate())).isTrue();
+
+        /* 5. Find after update */
+        FindMemoryDto.Response afterFindRsp = memoryService.find(insertRsp.getMemoryId());
+        assertThat(afterFindRsp).isNotNull();
+        assertThat(afterFindRsp.getName()).isEqualTo(updateReq.getName());
+        assertThat(afterFindRsp.getContents()).isEqualTo(updateReq.getContents());
+
+        /* 6. Delete memory */
         DeleteMemoryDto.Response deleteRsp = memoryService.delete(insertRsp.getMemoryId());
         assertThat(deleteRsp).isNotNull();
         assertThat(isNow(deleteRsp.getDeleteDate())).isTrue();
 
-        /* 4. Find after delete */
+        /* 7. Find after delete */
         Long memoryId = insertRsp.getMemoryId();
         assertThat(memoryId).isNotNull();
         assertThrows(
@@ -546,7 +625,7 @@ class MemoryServiceTest {
     @Test
     @Order(5)
     @Transactional
-    void RoomX_memberX_Memory() {
+    void RoomX_memberX() {
         /* 0-1. Create writer, member */
         User writer = userRepo.save(
                 User.builder()
@@ -617,7 +696,18 @@ class MemoryServiceTest {
                 null,       // 두 번째 알림
                 "#FFFFFF",  // 배경색
                 shareRooms     // 공유할 Room
-                );
+        );
+
+        UpdateMemoryDto.Request updateReq = new UpdateMemoryDto.Request(
+                "Update memory name",
+                "Update contents",
+                "Update place",
+                LocalDateTime.parse("2021-07-08 17:00", alertTimeFormat),
+                LocalDateTime.parse("2021-07-09 17:00", alertTimeFormat),
+                null,
+                null,
+                null
+        );
         
         /* 1. Make memory */
         InsertMemoryDto.Response insertRsp = memoryService.insert(insertReq);
@@ -638,14 +728,30 @@ class MemoryServiceTest {
         
         log.info("[RoomX_memberX_Memory_Read]");
         findMemoriesList.forEach(memory -> log.info(memory.toString()));
-        log.info("====================================================================================");
-        
-        /* 3. Delete memory */
+
+        /* 3. Find before update */
+        FindMemoryDto.Response beforeFindRsp = memoryService.find(insertRsp.getMemoryId());
+        assertThat(beforeFindRsp).isNotNull();
+        assertThat(beforeFindRsp.getName()).isEqualTo(insertRsp.getName());
+        assertThat(beforeFindRsp.getContents()).isEqualTo(insertRsp.getContents());
+
+        /* 4. Update */
+        UpdateMemoryDto.Response updateRsp = memoryService.update(insertRsp.getMemoryId(), updateReq);
+        assertThat(updateRsp).isNotNull();
+        assertThat(isNow(updateRsp.getUpdateDate())).isTrue();
+
+        /* 5. Find after update */
+        FindMemoryDto.Response afterFindRsp = memoryService.find(insertRsp.getMemoryId());
+        assertThat(afterFindRsp).isNotNull();
+        assertThat(afterFindRsp.getName()).isEqualTo(updateReq.getName());
+        assertThat(afterFindRsp.getContents()).isEqualTo(updateReq.getContents());
+
+        /* 6. Delete memory */
         DeleteMemoryDto.Response deleteRsp = memoryService.delete(insertRsp.getMemoryId());
         assertThat(deleteRsp).isNotNull();
         assertThat(isNow(deleteRsp.getDeleteDate())).isTrue();
 
-        /* 4. Find after delete */
+        /* 7. Find after delete */
         Long memoryId = insertRsp.getMemoryId();
         assertThat(memoryId).isNotNull();
         assertThrows(

--- a/OurMemory_Server/src/test/java/com/kds/ourmemory/service/v1/room/RoomServiceTest.java
+++ b/OurMemory_Server/src/test/java/com/kds/ourmemory/service/v1/room/RoomServiceTest.java
@@ -108,53 +108,56 @@ class RoomServiceTest {
         member.add(member2.getId());
 
         /* 0-2. Create request */
-        InsertRoomDto.Request insertRoomReq = new InsertRoomDto.Request("TestRoom", owner.getId(), false, member);
-        UpdateRoomDto.Request updateRoomReq = new UpdateRoomDto.Request("update room name", true);
+        InsertRoomDto.Request insertReq = new InsertRoomDto.Request("TestRoom", owner.getId(), false, member);
+        UpdateRoomDto.Request updateReq = new UpdateRoomDto.Request("update room name", true);
 
         /* 1. Insert */
-        InsertRoomDto.Response insertRoomRsp = roomService.insert(insertRoomReq);
-        assertThat(insertRoomRsp).isNotNull();
-        assertThat(insertRoomRsp.getOwnerId()).isEqualTo(owner.getId());
-        assertThat(insertRoomRsp.getMembers()).isNotNull();
-        assertThat(insertRoomRsp.getMembers().size()).isEqualTo(3);
+        InsertRoomDto.Response insertRsp = roomService.insert(insertReq);
+        assertThat(insertRsp).isNotNull();
+        assertThat(insertRsp.getOwnerId()).isEqualTo(owner.getId());
+        assertThat(insertRsp.getMembers()).isNotNull();
+        assertThat(insertRsp.getMembers().size()).isEqualTo(3);
 
-        /* 2. Find list */
+        /* 2. Find rooms */
         List<Room> findRooms = roomService.findRooms(owner.getId(), null);
         assertThat(findRooms).isNotNull();
 
-        log.info("[Room_목록_Read]");
+        findRooms = roomService.findRooms(null, "TestRoom");
+        assertThat(findRooms).isNotNull();
+
+        log.info("[Create_Read_Update_Delete] Find rooms");
         findRooms.forEach(room -> log.info(room.toString()));
 
         /* 3. Find before update */
-        FindRoomDto.Response beforeFindRoomRsp = roomService.find(insertRoomRsp.getRoomId());
-        assertThat(beforeFindRoomRsp).isNotNull();
-        assertThat(beforeFindRoomRsp.getName()).isEqualTo(insertRoomReq.getName());
-        assertThat(beforeFindRoomRsp.isOpened()).isEqualTo(insertRoomReq.isOpened());
+        FindRoomDto.Response beforeFindRsp = roomService.find(insertRsp.getRoomId());
+        assertThat(beforeFindRsp).isNotNull();
+        assertThat(beforeFindRsp.getName()).isEqualTo(insertReq.getName());
+        assertThat(beforeFindRsp.isOpened()).isEqualTo(insertReq.isOpened());
 
         /* 4. Update */
-        UpdateRoomDto.Response updateRoomRsp = roomService.update(insertRoomRsp.getRoomId(), updateRoomReq);
-        assertThat(updateRoomRsp).isNotNull();
-        assertThat(isNow(updateRoomRsp.getUpdateDate())).isTrue();
+        UpdateRoomDto.Response updateRsp = roomService.update(insertRsp.getRoomId(), updateReq);
+        assertThat(updateRsp).isNotNull();
+        assertThat(isNow(updateRsp.getUpdateDate())).isTrue();
 
         /* 5. Find after update */
-        FindRoomDto.Response afterFindRoomRsp = roomService.find(insertRoomRsp.getRoomId());
-        assertThat(afterFindRoomRsp).isNotNull();
-        assertThat(afterFindRoomRsp.getName()).isEqualTo(updateRoomReq.getName());
-        assertThat(afterFindRoomRsp.isOpened()).isEqualTo(updateRoomReq.getOpened());
+        FindRoomDto.Response afterFindRsp = roomService.find(insertRsp.getRoomId());
+        assertThat(afterFindRsp).isNotNull();
+        assertThat(afterFindRsp.getName()).isEqualTo(updateReq.getName());
+        assertThat(afterFindRsp.isOpened()).isEqualTo(updateReq.getOpened());
         
         /* 6. Delete */
-        DeleteRoomDto.Response deleteRoomRsp = roomService.delete(insertRoomRsp.getRoomId());
-        assertThat(deleteRoomRsp).isNotNull();
-        assertThat(isNow(deleteRoomRsp.getDeleteDate())).isTrue();
+        DeleteRoomDto.Response deleteRsp = roomService.delete(insertRsp.getRoomId());
+        assertThat(deleteRsp).isNotNull();
+        assertThat(isNow(deleteRsp.getDeleteDate())).isTrue();
 
         /* 7. Find after delete */
-        Long roomId = insertRoomRsp.getRoomId();
+        Long roomId = insertRsp.getRoomId();
         assertThat(roomId).isNotNull();
         assertThrows(
                 RoomNotFoundException.class, () -> roomService.find(roomId)
         );
 
-        log.info("deleteDate: {}", deleteRoomRsp.getDeleteDate());
+        log.info("deleteDate: {}", deleteRsp.getDeleteDate());
     }
     
     boolean isNow(String time) {


### PR DESCRIPTION
## #71 

## PR 설명
- 일정 관련 API 기능 수정

## 변경된 내용
- 일정 추가 시, 일정 정보 전달하도록 수정
- 일정 수정 기능 추가
- 일정 목록 조회 시, 일정 이름으로도 검색할 수 있도록 검색 조건 추가

## 추가적인 정보
- 방 삭제 시, 방에 포함된 일정도 삭제처리하도록 수정
- 방 목록 조회 시, 사용자 번호와 방 이름으로 정상 조회되도록 수정
- 친구 테이블 friend 컬럼 객체 friendUser 로 수정
   실제 테이블 값은 friend_id 로 유지함.