### PR TITLE
Fix/#47 memory find add

### DIFF
--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="Encoding">
+  <component name="Encoding" native2AsciiForPropertiesFiles="true" defaultCharsetForPropertiesFiles="UTF-8">
     <file url="file://$PROJECT_DIR$/OurMemory_Server/src/main/java/com/kds/ourmemory/service/v1/friend/FriendService.java" charset="UTF-8" />
+    <file url="PROJECT" charset="UTF-8" />
   </component>
 </project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -5,7 +5,7 @@
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
         <option name="delegatedBuild" value="true" />
-        <option name="testRunner" value="GRADLE" />
+        <option name="testRunner" value="PLATFORM" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$/OurMemory_Server" />
         <option name="gradleJvm" value="#JAVA_HOME" />

--- a/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/memory/dto/FindMemoriesDto.java
+++ b/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/memory/dto/FindMemoriesDto.java
@@ -2,6 +2,7 @@ package com.kds.ourmemory.controller.v1.memory.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.kds.ourmemory.entity.memory.Memory;
+import com.kds.ourmemory.entity.room.Room;
 import com.kds.ourmemory.entity.user.User;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -63,6 +64,9 @@ public class FindMemoriesDto {
         
         @ApiModelProperty(value = "일정 참여자", notes = "일정을 생성한 사람도 참여자에 포함되어 전달됨.", example = "[{참여자1}, {참여자2}]")
         private final List<Member> members;
+
+        @ApiModelProperty(value = "일정 공유방 목록", notes = "일정이 공유된 방 목록")
+        private final List<ShareRoom> shareRooms;
         
         public Response(Memory memory) {
             memoryId = memory.getId();
@@ -78,6 +82,8 @@ public class FindMemoriesDto {
             regDate = memory.formatRegDate();
             modDate = memory.formatModDate();
             members = memory.getUsers().stream().filter(User::isUsed).map(Member::new)
+                    .collect(Collectors.toList());
+            shareRooms = memory.getRooms().stream().filter(Room::isUsed).map(ShareRoom::new)
                     .collect(Collectors.toList());
         }
         
@@ -102,7 +108,7 @@ public class FindMemoriesDto {
             @ApiModelProperty(value = "생일 공개여부", example = "false")
             private final boolean birthdayOpen;
             
-            public Member(User user) {
+            private Member(User user) {
                 userId = user.getId();
                 name = user.getName();
                 birthday = user.isBirthdayOpen() ? user.getBirthday() : null;
@@ -110,6 +116,29 @@ public class FindMemoriesDto {
                 birthdayOpen = user.isBirthdayOpen();
             }
         }
+
+        /**
+         * Memory room non static inner class
+         */
+        @ApiModel(value = "FindMemoriesResponse.ShareRoom", description = "inner class in FindMemoriesDto.Response")
+        @Getter
+        private class ShareRoom {
+            @ApiModelProperty(value = "방 번호", example = "49")
+            private final Long roomId;
+
+            @ApiModelProperty(value = "방 소유자 번호", example = "99")
+            private final Long ownerId;
+
+            @ApiModelProperty(value = "방 이름", example = "프로젝트 방")
+            private final String name;
+
+            private ShareRoom(Room room) {
+                roomId = room.getId();
+                ownerId = room.getOwner().getId();
+                name = room.getName();
+            }
+        }
+
     }
 
 }

--- a/OurMemory_Server/src/main/java/com/kds/ourmemory/entity/memory/Memory.java
+++ b/OurMemory_Server/src/main/java/com/kds/ourmemory/entity/memory/Memory.java
@@ -13,10 +13,8 @@ import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 @ToString(exclude = {"rooms", "users"})
@@ -78,11 +76,8 @@ public class Memory extends BaseTimeEntity implements Serializable {
         checkNotNull(name, "일정 제목이 입력되지 않았습니다. 일정 제목을 입력해주세요.");
         
         checkNotNull(startDate, "일정 시작시간이 입력되지 않았습니다. 일정 시작시간을 입력해주세요.");
-        checkArgument(startDate.isAfter(LocalDateTime.now()), "일정 시작시간은 현재시간보다 이전일 수 없습니다.");
-
         checkNotNull(endDate, "일정 종료시간이 입력되지 않았습니다. 일정 종료시간을 입력해주세요.");
-        checkArgument(endDate.isAfter(startDate), "일정 종료시간은 일정 시작시간보다 이전일 수 없습니다.");
-        
+
         checkNotNull(bgColor, "일정 배경색이 지정되지 않았습니다. 배경색을 지정해주세요.");
         
         this.id = id;
@@ -111,14 +106,14 @@ public class Memory extends BaseTimeEntity implements Serializable {
     public Optional<Memory> updateMemory(UpdateMemoryDto.Request request) {
         return Optional.ofNullable(request)
                 .map(req -> {
-                    name = Objects.nonNull(req.getName()) ? req.getName() : name;
-                    contents = Objects.nonNull(req.getContents()) ? req.getContents() : contents;
-                    place = Objects.nonNull(req.getPlace()) ? req.getPlace() : place;
-                    startDate = Objects.nonNull(req.getStartDate()) ? req.getStartDate() : startDate;
-                    endDate = Objects.nonNull(req.getEndDate()) ? req.getEndDate() : endDate;
-                    firstAlarm = Objects.nonNull(req.getFirstAlarm()) ? req.getFirstAlarm() : firstAlarm;
-                    secondAlarm = Objects.nonNull(req.getSecondAlarm()) ? req.getSecondAlarm() : secondAlarm;
-                    bgColor = Objects.nonNull(req.getBgColor()) ? req.getBgColor() : bgColor;
+                    Optional.ofNullable(req.getName()).ifPresent(reqName -> this.name = reqName);
+                    Optional.ofNullable(req.getContents()).ifPresent(reqContents -> this.contents = reqContents);
+                    Optional.ofNullable(req.getPlace()).ifPresent(reqPlace -> this.place = reqPlace);
+                    Optional.ofNullable(req.getStartDate()).ifPresent(reqStartDate -> this.startDate = reqStartDate);
+                    Optional.ofNullable(req.getEndDate()).ifPresent(reqEndDate -> this.endDate = reqEndDate);
+                    Optional.ofNullable(req.getFirstAlarm()).ifPresent(reqFirstAlarm -> this.firstAlarm = reqFirstAlarm);
+                    Optional.ofNullable(req.getSecondAlarm()).ifPresent(reqSecondAlarm -> this.secondAlarm = reqSecondAlarm);
+                    Optional.ofNullable(req.getBgColor()).ifPresent(reqBgColor -> this.bgColor = reqBgColor);
 
                     return this;
                 });

--- a/OurMemory_Server/src/test/java/com/kds/ourmemory/service/v1/memory/MemoryServiceTest.java
+++ b/OurMemory_Server/src/test/java/com/kds/ourmemory/service/v1/memory/MemoryServiceTest.java
@@ -73,8 +73,9 @@ class MemoryServiceTest {
     
     @Test
     @Order(1)
+    @DisplayName("메인방[O] 참여자[O] 포함[O]")
     @Transactional
-    void RoomO_memberO() {
+    void mainRoomAndIncludeMembers() {
         /* 0-1. Create writer, member */
         User writer = userRepo.save(
                 User.builder()
@@ -106,12 +107,12 @@ class MemoryServiceTest {
                         .build()
         );
 
-        User member_IncludeX = userRepo.save(
+        User excludeMember = userRepo.save(
                 User.builder()
-                        .snsId("member_IncludeX_snsId")
+                        .snsId("excludeMember_snsId")
                         .snsType(2)
-                        .pushToken("member_IncludeX Token")
-                        .name("member_IncludeX")
+                        .pushToken("excludeMember Token")
+                        .name("excludeMember")
                         .birthday("0807")
                         .solar(true)
                         .birthdayOpen(true)
@@ -126,7 +127,7 @@ class MemoryServiceTest {
         mainRoom_member.add(member.getId());
         InsertRoomDto.Response mainRoom = roomService.insert(new InsertRoomDto.Request("mainRoom", writer.getId(), false, mainRoom_member));
         InsertRoomDto.Response shareRoom1 = roomService.insert(new InsertRoomDto.Request("shareRoom1", member.getId(), false, mainRoom_member));
-        InsertRoomDto.Response shareRoom2 = roomService.insert(new InsertRoomDto.Request("shareRoom2", member_IncludeX.getId(), false, mainRoom_member));
+        InsertRoomDto.Response shareRoom2 = roomService.insert(new InsertRoomDto.Request("shareRoom2", excludeMember.getId(), false, mainRoom_member));
         
         List<Long> shareRooms = new ArrayList<>();
         shareRooms.add(shareRoom1.getRoomId());
@@ -175,8 +176,12 @@ class MemoryServiceTest {
         FindMemoriesDto.Response findMemoriesRsp = findMemoriesList.get(0);
         assertThat(findMemoriesRsp).isNotNull();
         assertThat(findMemoriesRsp.getMemoryId()).isEqualTo(insertRsp.getMemoryId());
+        assertThat(findMemoriesRsp.getMembers()).isNotNull();
+        assertThat(findMemoriesRsp.getMembers().size()).isEqualTo(2);
+        assertThat(findMemoriesRsp.getShareRooms()).isNotNull();
+        assertThat(findMemoriesRsp.getShareRooms().size()).isEqualTo(3);
         
-        log.info("[RoomO_memberO_Memory_Read] Find memories");
+        log.info("[메인방[O] 참여자[O] 포함[O]] Find memories");
         findMemoriesList.forEach(memory -> log.info(memory.toString()));
 
         /* 3. Find before update */
@@ -211,8 +216,9 @@ class MemoryServiceTest {
     
     @Test
     @Order(2)
+    @DisplayName("메인방[O] 참여자[O] 포함[X]")
     @Transactional
-    void RoomO_memberO_IncludeX() {
+    void mainRoomAndExcludeMembers() {
         /* 0-1. Create writer, member */
         User writer = userRepo.save(
                 User.builder()
@@ -244,12 +250,12 @@ class MemoryServiceTest {
                         .build()
         );
 
-        User member_IncludeX = userRepo.save(
+        User excludeMember = userRepo.save(
                 User.builder()
-                        .snsId("member_IncludeX_snsId")
+                        .snsId("excludeMember_snsId")
                         .snsType(2)
-                        .pushToken("member_IncludeX Token")
-                        .name("member_IncludeX")
+                        .pushToken("excludeMember Token")
+                        .name("excludeMember")
                         .birthday("0807")
                         .solar(true)
                         .birthdayOpen(true)
@@ -264,7 +270,7 @@ class MemoryServiceTest {
         mainRoom_member.add(member.getId());
         InsertRoomDto.Response mainRoom = roomService.insert(new InsertRoomDto.Request("mainRoom", writer.getId(), false, mainRoom_member));
         InsertRoomDto.Response shareRoom1 = roomService.insert(new InsertRoomDto.Request("shareRoom1", member.getId(), false, mainRoom_member));
-        InsertRoomDto.Response shareRoom2 = roomService.insert(new InsertRoomDto.Request("shareRoom2", member_IncludeX.getId(), false, mainRoom_member));
+        InsertRoomDto.Response shareRoom2 = roomService.insert(new InsertRoomDto.Request("shareRoom2", excludeMember.getId(), false, mainRoom_member));
         
         List<Long> shareRooms = new ArrayList<>();
         shareRooms.add(shareRoom1.getRoomId());
@@ -275,7 +281,7 @@ class MemoryServiceTest {
                 writer.getId(),
                 mainRoom.getRoomId(),
                 "Test Memory",
-                Stream.of(member_IncludeX.getId()).collect(Collectors.toList()),
+                Stream.of(excludeMember.getId()).collect(Collectors.toList()),
                 "Test Contents", 
                 "Test Place", 
                 LocalDateTime.parse("2022-03-26 17:00", alertTimeFormat), // 시작 시간 
@@ -313,8 +319,12 @@ class MemoryServiceTest {
         FindMemoriesDto.Response findMemoriesRsp = findMemoriesList.get(0);
         assertThat(findMemoriesRsp).isNotNull();
         assertThat(findMemoriesRsp.getMemoryId()).isEqualTo(insertRsp.getMemoryId());
+        assertThat(findMemoriesRsp.getMembers()).isNotNull();
+        assertThat(findMemoriesRsp.getMembers().size()).isEqualTo(2);
+        assertThat(findMemoriesRsp.getShareRooms()).isNotNull();
+        assertThat(findMemoriesRsp.getShareRooms().size()).isEqualTo(3);
         
-        log.info("[RoomO_memberO_IncludeX_Memory_Read]");
+        log.info("[메인방[O] 참여자[O] 포함[X]] Find Memories");
         findMemoriesList.forEach(memory -> log.info(memory.toString()));
 
         /* 3. Find before update */
@@ -349,8 +359,9 @@ class MemoryServiceTest {
     
     @Test
     @Order(3)
+    @DisplayName("메인방[O] 참여자[X]")
     @Transactional
-    void RoomO_memberX() {
+    void mainRoomAndNoMembers() {
         /* 0-1. Create writer, member */
         User writer = userRepo.save(
                 User.builder()
@@ -382,12 +393,12 @@ class MemoryServiceTest {
                         .build()
         );
 
-        User member_IncludeX = userRepo.save(
+        User excludeMember = userRepo.save(
                 User.builder()
-                        .snsId("member_IncludeX_snsId")
+                        .snsId("excludeMember_snsId")
                         .snsType(2)
-                        .pushToken("member_IncludeX Token")
-                        .name("member_IncludeX")
+                        .pushToken("excludeMember Token")
+                        .name("excludeMember")
                         .birthday("0807")
                         .solar(true)
                         .birthdayOpen(true)
@@ -402,7 +413,7 @@ class MemoryServiceTest {
         mainRoom_member.add(member.getId());
         InsertRoomDto.Response mainRoom = roomService.insert(new InsertRoomDto.Request("mainRoom", writer.getId(), false, mainRoom_member));
         InsertRoomDto.Response shareRoom1 = roomService.insert(new InsertRoomDto.Request("shareRoom1", member.getId(), false, mainRoom_member));
-        InsertRoomDto.Response shareRoom2 = roomService.insert(new InsertRoomDto.Request("shareRoom2", member_IncludeX.getId(), false, mainRoom_member));
+        InsertRoomDto.Response shareRoom2 = roomService.insert(new InsertRoomDto.Request("shareRoom2", excludeMember.getId(), false, mainRoom_member));
         
         List<Long> shareRooms = new ArrayList<>();
         shareRooms.add(shareRoom1.getRoomId());
@@ -451,8 +462,12 @@ class MemoryServiceTest {
         FindMemoriesDto.Response findMemoriesRsp = findMemoriesList.get(0);
         assertThat(findMemoriesRsp).isNotNull();
         assertThat(findMemoriesRsp.getMemoryId()).isEqualTo(insertRsp.getMemoryId());
-        
-        log.info("[RoomO_memberX_Memory_Read]");
+        assertThat(findMemoriesRsp.getMembers()).isNotNull();
+        assertThat(findMemoriesRsp.getMembers().size()).isOne();
+        assertThat(findMemoriesRsp.getShareRooms()).isNotNull();
+        assertThat(findMemoriesRsp.getShareRooms().size()).isEqualTo(3);
+
+        log.info("[메인방[O] 참여자[X]] Find memories");
         findMemoriesList.forEach(memory -> log.info(memory.toString()));
 
         /* 3. Find before update */
@@ -487,8 +502,9 @@ class MemoryServiceTest {
     
     @Test
     @Order(4)
+    @DisplayName("메인방[X] 참여자[O]")
     @Transactional
-    void RoomX_memberO() {
+    void noMainRoomAndMembers() {
         /* 0-1. Create writer, member */
         User writer = userRepo.save(
                 User.builder()
@@ -520,12 +536,12 @@ class MemoryServiceTest {
                         .build()
         );
 
-        User member_IncludeX = userRepo.save(
+        User excludeMember = userRepo.save(
                 User.builder()
-                        .snsId("member_IncludeX_snsId")
+                        .snsId("excludeMember_snsId")
                         .snsType(2)
-                        .pushToken("member_IncludeX Token")
-                        .name("member_IncludeX")
+                        .pushToken("excludeMember Token")
+                        .name("excludeMember")
                         .birthday("0807")
                         .solar(true)
                         .birthdayOpen(true)
@@ -539,7 +555,7 @@ class MemoryServiceTest {
         List<Long> mainRoom_member = new ArrayList<>();
         mainRoom_member.add(member.getId());
         InsertRoomDto.Response shareRoom1 = roomService.insert(new InsertRoomDto.Request("shareRoom1", member.getId(), false, mainRoom_member));
-        InsertRoomDto.Response shareRoom2 = roomService.insert(new InsertRoomDto.Request("shareRoom2", member_IncludeX.getId(), false, mainRoom_member));
+        InsertRoomDto.Response shareRoom2 = roomService.insert(new InsertRoomDto.Request("shareRoom2", excludeMember.getId(), false, mainRoom_member));
         
         List<Long> shareRooms = new ArrayList<>();
         shareRooms.add(shareRoom1.getRoomId());
@@ -588,8 +604,12 @@ class MemoryServiceTest {
         FindMemoriesDto.Response findMemoriesRsp = findMemoriesList.get(0);
         assertThat(findMemoriesRsp).isNotNull();
         assertThat(findMemoriesRsp.getMemoryId()).isEqualTo(insertRsp.getMemoryId());
-        
-        log.info("[RoomX_memberO_Memory_Read]");
+        assertThat(findMemoriesRsp.getMembers()).isNotNull();
+        assertThat(findMemoriesRsp.getMembers().size()).isEqualTo(2);
+        assertThat(findMemoriesRsp.getShareRooms()).isNotNull();
+        assertThat(findMemoriesRsp.getShareRooms().size()).isEqualTo(3);
+
+        log.info("[메인방[X] 참여자[O]] Find memories");
         findMemoriesList.forEach(memory -> log.info(memory.toString()));
 
         /* 3. Find before update */
@@ -624,8 +644,9 @@ class MemoryServiceTest {
     
     @Test
     @Order(5)
+    @DisplayName("메인방[X] 참여자[X] - 개인 일정")
     @Transactional
-    void RoomX_memberX() {
+    void noMainRoomAndNoMembers() {
         /* 0-1. Create writer, member */
         User writer = userRepo.save(
                 User.builder()
@@ -657,12 +678,12 @@ class MemoryServiceTest {
                         .build()
         );
 
-        User member_IncludeX = userRepo.save(
+        User excludeMember = userRepo.save(
                 User.builder()
-                        .snsId("member_IncludeX_snsId")
+                        .snsId("excludeMember_snsId")
                         .snsType(2)
-                        .pushToken("member_IncludeX Token")
-                        .name("member_IncludeX")
+                        .pushToken("excludeMember Token")
+                        .name("excludeMember")
                         .birthday("0807")
                         .solar(true)
                         .birthdayOpen(true)
@@ -676,7 +697,7 @@ class MemoryServiceTest {
         List<Long> mainRoom_member = new ArrayList<>();
         mainRoom_member.add(member.getId());
         InsertRoomDto.Response shareRoom1 = roomService.insert(new InsertRoomDto.Request("shareRoom1", member.getId(), false, mainRoom_member));
-        InsertRoomDto.Response shareRoom2 = roomService.insert(new InsertRoomDto.Request("shareRoom2", member_IncludeX.getId(), false, mainRoom_member));
+        InsertRoomDto.Response shareRoom2 = roomService.insert(new InsertRoomDto.Request("shareRoom2", excludeMember.getId(), false, mainRoom_member));
         
         List<Long> shareRooms = new ArrayList<>();
         shareRooms.add(shareRoom1.getRoomId());
@@ -687,7 +708,7 @@ class MemoryServiceTest {
                 writer.getId(),
                 null,
                 "Test Memory",
-                null,
+                new ArrayList<>(),
                 "Test Contents", 
                 "Test Place", 
                 LocalDateTime.parse("2022-03-26 17:00", alertTimeFormat), // 시작 시간 
@@ -725,8 +746,12 @@ class MemoryServiceTest {
         FindMemoriesDto.Response findMemoriesRsp = findMemoriesList.get(0);
         assertThat(findMemoriesRsp).isNotNull();
         assertThat(findMemoriesRsp.getMemoryId()).isEqualTo(insertRsp.getMemoryId());
+        assertThat(findMemoriesRsp.getMembers()).isNotNull();
+        assertThat(findMemoriesRsp.getMembers().size()).isOne();
+        assertThat(findMemoriesRsp.getShareRooms()).isNotNull();
+        assertThat(findMemoriesRsp.getShareRooms().size()).isEqualTo(2);
         
-        log.info("[RoomX_memberX_Memory_Read]");
+        log.info("[메인방[X] 참여자[X] - 개인일정] Find memories");
         findMemoriesList.forEach(memory -> log.info(memory.toString()));
 
         /* 3. Find before update */


### PR DESCRIPTION
## #79

## PR 설명
- 일정 목록 조회, 추가 기능 수정

## 변경된 내용
- 일정 목록 조회 시, 응답데이터에 일정을 포함하는 방 목록도 전달하도록 수정
- 일정 추가 시, 개인 일정인 경우 방이 생성되지 않도록 수정

## 추가적인 정보
- 일정이 공유된 방에 대해 메인방, 공유방 구분이 필요하다.
   전체적인 수정이 완료된 뒤 해당 기능을 추후 구현하도록 한다.