### PR TITLE
Fix/#135 sign in response private room id

### DIFF
--- a/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/user/dto/SignInUserDto.java
+++ b/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/user/dto/SignInUserDto.java
@@ -2,6 +2,7 @@ package com.kds.ourmemory.controller.v1.user.dto;
 
 import com.kds.ourmemory.entity.user.User;
 
+import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AccessLevel;
@@ -35,6 +36,9 @@ public class SignInUserDto {
         @ApiModelProperty(value = "푸시 사용 여부")
         private final boolean push;
 
+        @ApiModelProperty(value = "개인방 번호")
+        private final long privateRoomId;
+
         public Response(User user) {
             userId = user.getId();
             name = user.getName();
@@ -43,6 +47,7 @@ public class SignInUserDto {
             birthdayOpen = user.isBirthdayOpen();
             pushToken = user.getPushToken();
             push = user.isPush();
+            privateRoomId = user.getPrivateRoomId();
         }
     }
 }

--- a/OurMemory_Server/src/test/java/com/kds/ourmemory/service/v1/user/UserServiceTest.java
+++ b/OurMemory_Server/src/test/java/com/kds/ourmemory/service/v1/user/UserServiceTest.java
@@ -30,8 +30,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -98,6 +97,7 @@ class UserServiceTest {
         assertThat(signInRsp.getPushToken()).isEqualTo(insertReq.getPushToken());
         assertThat(signInRsp.getBirthday()).isEqualTo(insertReq.getBirthday());
         assertTrue(signInRsp.isPush());
+        assertThat(signInRsp.getPrivateRoomId()).isEqualTo(insertRsp.getPrivateRoomId());
 
         /* 3. Find */
         var findRsp = userService.find(insertRsp.getUserId());
@@ -744,7 +744,7 @@ class UserServiceTest {
         /* 0-1. Sign in before delete */
         var beforeSignInRsp = userService.signIn(insertUserReq.getSnsType(), insertUserReq.getSnsId());
         assertThat(beforeSignInRsp).isNotNull();
-        assertThat(beforeSignInRsp.getUserId()).isEqualTo(insertUserRsp.getUserId());
+        assertEquals(beforeSignInRsp.getUserId(), insertUserRsp.getUserId());
 
         /* 0-2. Delete user */
         var deleteUserRsp = userService.delete(insertUserRsp.getUserId());
@@ -766,6 +766,7 @@ class UserServiceTest {
         var afterSignInRsp = userService.signIn(insertUserReq.getSnsType(), insertUserReq.getSnsId());
         assertThat(afterSignInRsp).isNotNull();
         assertThat(afterSignInRsp.getUserId()).isEqualTo(reInsertUserRsp.getUserId());
+        assertNotEquals(afterSignInRsp.getPrivateRoomId(), beforeSignInRsp.getPrivateRoomId());
     }
     
     boolean isNow(String time) {


### PR DESCRIPTION
## #135 

## PR 설명
- 로그인 기능 수정

## 변경된 내용
- 응답 프로토콜에 개인방 번호 추가

## 추가적인 정보
- 일정 삭제 시, 방 번호를 전달하게 됨에 따라 수정하게 됨.
  -> 개인 일정은 방 없이도 따로 보는 기능이 존재하기 때문에 개인방 번호를 따로 관리한다.