### PR TITLE
Fix/#176 move find users to friend apis

### DIFF
--- a/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/friend/FriendController.java
+++ b/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/friend/FriendController.java
@@ -20,6 +20,12 @@ import static com.kds.ourmemory.controller.v1.ApiResult.ok;
 public class FriendController {
     private final FriendService friendService;
 
+    @ApiOperation(value = "사용자 검색", notes = "조건에 해당하는 사용자의 기본 정보와 친구 상태를 검색한다.")
+    @GetMapping(value = "/users/{userId}/search")
+    public ApiResult<List<FriendDto>> findUsers(@PathVariable long userId, @RequestBody FriendDto request) {
+        return ok(friendService.findUsers(userId, request));
+    }
+
     @ApiOperation(value = "친구 요청", notes = "사용자에게 친구 요청 푸시 알림을 전송한다. 차단한 상대에게는 요청이 전달되지 않는다.")
     @PostMapping(value = "/request")
     public ApiResult<FriendDto> requestFriend(@RequestBody RequestFriendDto.Request request) {

--- a/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/friend/dto/FriendDto.java
+++ b/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/friend/dto/FriendDto.java
@@ -2,23 +2,28 @@ package com.kds.ourmemory.controller.v1.friend.dto;
 
 import com.kds.ourmemory.entity.friend.Friend;
 import com.kds.ourmemory.entity.friend.FriendStatus;
+import com.kds.ourmemory.entity.user.User;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @ApiModel(value = "FriendDto", description = "Friend API Dto")
+@Builder
+@AllArgsConstructor
 @Getter
 @NoArgsConstructor
 public class FriendDto {
 
     @ApiModelProperty(value = "친구 번호(친구 사용자 번호)", example = "99")
-    private long friendId;
+    private Long friendId;
 
     @ApiModelProperty(value = "친구 이름", example = "김동영")
     private String name;
 
-    @ApiModelProperty(value = "친구 생일", example = "0724 | null")
+    @ApiModelProperty(value = "친구 생일(MMdd)", example = "0724 | null")
     private String birthday;
 
     @ApiModelProperty(value = "양력 여부", example = "true")
@@ -41,6 +46,17 @@ public class FriendDto {
         birthdayOpen = friend.getFriendUser().isBirthdayOpen();
         profileImageUrl = friend.getFriendUser().getProfileImageUrl();
         friendStatus = friend.getStatus();
+    }
+
+    // used for findUsers API Response
+    public FriendDto(User user, Friend friend) {
+        friendId = user.getId();
+        name = user.getName();
+        birthday = user.getBirthday();
+        solar = user.isSolar();
+        birthdayOpen = user.isBirthdayOpen();
+        profileImageUrl = user.getProfileImageUrl();
+        friendStatus = friend != null ? friend.getStatus() : null;
     }
 
 }

--- a/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/memory/MemoryController.java
+++ b/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/memory/MemoryController.java
@@ -68,9 +68,9 @@ public class MemoryController {
     @ApiOperation(value = "일정 공유",
             notes = """
                     사용자가 대상 목록에게 일정을 공유시킨다.\s
-                    1. 사용자 개별 공유: 각 사용자 별로 방 생성 뒤 일정 공유,\s
-                    2. 사용자 그룹 공유: 사용자들을 참여자로 방 생성 후 일정 공유,\s
-                    3. 기존 방에 공유: 전달받은 각각의 방에 일정 공유"""
+                    1. 사용자 개별 공유: 각 사용자 별로 방 생성 뒤 일정 공유(type=USERS, targetIds=사용자 번호 목록)\s
+                    2. 사용자 그룹 공유: 사용자들을 참여자로 방 생성 후 일정 공유(type=USER_GROUP, targetIds=사용자 번호 목록)\s
+                    3. 기존 방에 공유: 전달받은 각각의 방에 일정 공유(type=ROOMS, targetIds=방 번호 목록)"""
     )
     @PostMapping("/{memoryId}/share/{userId}")
     public ApiResult<MemoryDto> shareMemory(

--- a/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/memory/dto/MemoryDto.java
+++ b/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/memory/dto/MemoryDto.java
@@ -35,28 +35,28 @@ public class MemoryDto {
     private final String place;
 
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
-    @ApiModelProperty(value = "시작 시간", notes = "yyyy-MM-dd HH:mm")
+    @ApiModelProperty(value = "시작 시간(yyyy-MM-dd HH:mm)", notes = "yyyy-MM-dd HH:mm")
     private final LocalDateTime startDate;
 
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
-    @ApiModelProperty(value = "종료 시간", notes = "yyyy-MM-dd HH:mm")
+    @ApiModelProperty(value = "종료 시간(yyyy-MM-dd HH:mm)", notes = "yyyy-MM-dd HH:mm")
     private final LocalDateTime endDate;
 
-    @ApiModelProperty(value = "배경색", example = "#FFFFFF")
+    @ApiModelProperty(value = "배경색(16진 색상코드)", example = "#FFFFFF")
     private final String bgColor;
 
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
-    @ApiModelProperty(value = "첫 번째 알림 시간", notes = "yyyy-MM-dd HH:mm")
+    @ApiModelProperty(value = "첫 번째 알림 시간(yyyy-MM-dd HH:mm)", notes = "yyyy-MM-dd HH:mm")
     private final LocalDateTime firstAlarm;
 
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
-    @ApiModelProperty(value = "두 번째 알림 시간", notes = "yyyy-MM-dd HH:mm")
+    @ApiModelProperty(value = "두 번째 알림 시간(yyyy-MM-dd HH:mm)", notes = "yyyy-MM-dd HH:mm")
     private final LocalDateTime secondAlarm;
 
-    @ApiModelProperty(value = "일정 등록날짜", notes = "yyyy-MM-dd HH:mm:ss")
+    @ApiModelProperty(value = "일정 등록날짜(yyyy-MM-dd HH:mm:ss)", notes = "yyyy-MM-dd HH:mm:ss")
     private final String regDate;
 
-    @ApiModelProperty(value = "일정 수정날짜", notes = "yyyy-MM-dd HH:mm:ss")
+    @ApiModelProperty(value = "일정 수정날짜(yyyy-MM-dd HH:mm:ss)", notes = "yyyy-MM-dd HH:mm:ss")
     private final String modDate;
 
     @ApiModelProperty(value = "일정 공유방 목록", notes = "일정이 공유된 방 목록")
@@ -65,7 +65,7 @@ public class MemoryDto {
     @ApiModelProperty(value = "일정이 추가된 방", notes = "일정이 추가된 방 번호를 전달한다. 개인 일정인 경우 개인방 번호가 전달된다.")
     private Long addedRoomId;
 
-    @ApiModelProperty(value = "참석 여부 목록", notes = "일정을 조회한 방 인원에 대한 참석 여부 목록을 전달한다. 참석 여부를 설정하지 않은 경우 미정으로 취급한다.")
+    @ApiModelProperty(value = "참석 여부 목록(ABSENCE: 불참, ATTEND: 참석)", notes = "일정을 조회한 방 인원에 대한 참석 여부 목록을 전달한다. 참석 여부를 설정하지 않은 경우 미정으로 취급한다.")
     private List<UserAttendance> userAttendances;
 
     public MemoryDto(Memory memory) {

--- a/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/notice/dto/NoticeDto.java
+++ b/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/notice/dto/NoticeDto.java
@@ -13,7 +13,7 @@ public class NoticeDto {
     @ApiModelProperty(value = "알림 번호")
     private final long noticeId;
 
-    @ApiModelProperty(value = "알림 종류", example = "FRIEND_REQUEST")
+    @ApiModelProperty(value = "알림 종류(FRIEND_REQUEST: 친구 요청)", example = "FRIEND_REQUEST")
     private final NoticeType type;
 
     @ApiModelProperty(value = "알림 문자열 값", example = "99")
@@ -22,7 +22,7 @@ public class NoticeDto {
     @ApiModelProperty(value = "알림 읽음 여부", example = "true")
     private final boolean read;
 
-    @ApiModelProperty(value = "알림 생성 날짜", notes = "yyyy-MM-dd HH:mm:ss")
+    @ApiModelProperty(value = "알림 생성 날짜(yyyy-MM-dd HH:mm:ss)", notes = "yyyy-MM-dd HH:mm:ss")
     private final String regDate;
 
     public NoticeDto(Notice notice) {

--- a/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/todo/TodoController.java
+++ b/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/todo/TodoController.java
@@ -31,7 +31,7 @@ public class TodoController {
         return ok(todoService.find(todoId));
     }
 
-    @ApiOperation(value = "TODO 리스트 조회", notes = "사용자가 작성한 TODO 리스트를 조회한다.")
+    @ApiOperation(value = "TODO 목록 조회", notes = "사용자가 작성한 TODO 목록을 조회한다.")
     @GetMapping("/user/{userId}")
     public ApiResult<List<FindTodosDto.Response>> findTodos(@PathVariable long userId) {
         return ok(todoService.findTodos(userId));

--- a/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/user/UserController.java
+++ b/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/user/UserController.java
@@ -2,8 +2,6 @@ package com.kds.ourmemory.controller.v1.user;
 
 import com.kds.ourmemory.controller.v1.ApiResult;
 import com.kds.ourmemory.controller.v1.user.dto.*;
-import com.kds.ourmemory.entity.friend.FriendStatus;
-import com.kds.ourmemory.entity.user.User;
 import com.kds.ourmemory.service.v1.user.UserService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -11,8 +9,6 @@ import io.swagger.annotations.ApiParam;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 import static com.kds.ourmemory.controller.v1.ApiResult.ok;
 
@@ -44,17 +40,6 @@ public class UserController {
             @ApiParam(value = "userId", required = true) @PathVariable long userId
     ) {
         return ok(userService.find(userId));
-    }
-
-    @ApiOperation(value = "사용자 검색", notes = "조건에 해당하는 사용자를 검색한다. 또한 나와의 친구상태도 검색된다.")
-    @GetMapping(value = "/{userId}/search")
-    public ApiResult<List<UserDto>> findUsers(
-            @PathVariable long userId,
-            @ApiParam(value = "findId") @RequestParam(required = false) Long findId,
-            @ApiParam(value = "name") @RequestParam(required = false) String name,
-            @ApiParam(value = "friendStatus") @RequestParam(required = false) FriendStatus friendStatus
-    ) {
-        return ok(userService.findUsers(userId, findId, name, friendStatus));
     }
 
     @ApiOperation(value = "푸시 토큰 수정", notes = "사용자 번호로 사용자를 찾아 푸시토큰 값을 수정한다.")

--- a/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/user/dto/UserDto.java
+++ b/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/user/dto/UserDto.java
@@ -1,15 +1,11 @@
 package com.kds.ourmemory.controller.v1.user.dto;
 
-import com.kds.ourmemory.entity.friend.Friend;
-import com.kds.ourmemory.entity.friend.FriendStatus;
 import com.kds.ourmemory.entity.user.DeviceOs;
 import com.kds.ourmemory.entity.user.User;
 import com.kds.ourmemory.entity.user.UserRole;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.Getter;
-
-import java.util.Objects;
 
 @ApiModel(value = "UserDto", description = "사용자 API 응답 Dto")
 @Getter
@@ -20,7 +16,7 @@ public class UserDto {
     @ApiModelProperty(value = "사용자 이름", example = "김동영")
     private final String name;
 
-    @ApiModelProperty(value = "사용자 생일", example = "null")
+    @ApiModelProperty(value = "사용자 생일(MMdd)", example = "0711")
     private final String birthday;
 
     @ApiModelProperty(value = "양력 여부", example = "true")
@@ -47,19 +43,14 @@ public class UserDto {
     @ApiModelProperty(value = "프로필사진 Url")
     private final String profileImageUrl;
 
-    @ApiModelProperty(value = "역할", example = "USER or ADMIN")
+    @ApiModelProperty(value = "역할(USER:사용자, ADMIN:관리자)", example = "USER or ADMIN")
     private final UserRole role;
 
-    @ApiModelProperty(value = "사용기기 OS", example = "ANDROID or IOS")
+    @ApiModelProperty(value = "사용기기 OS(ANDROID, IOS)", example = "ANDROID or IOS")
     private final DeviceOs deviceOs;
 
     @ApiModelProperty(value = "계정 사용여부")
     private final boolean used;
-
-    /* used for findUsers API Response */
-    @ApiModelProperty(value = "친구 상태(요청 후 대기: WAIT, 요청받은 상태: REQUESTED_BY, 친구: FRIEND, 차단: BLOCK | 관계없음: null)"
-            , example = "FRIEND")
-    private FriendStatus friendStatus;
 
     public UserDto(User user) {
         this.userId = user.getId();
@@ -78,22 +69,4 @@ public class UserDto {
         this.used = user.isUsed();
     }
 
-    public UserDto(User user, Friend friend) {
-        this.userId = user.getId();
-        this.name = user.getName();
-        this.solar = user.isSolar();
-        this.birthdayOpen = user.isBirthdayOpen();
-        this.birthday = user.getBirthday();
-        this.pushToken = user.getPushToken();
-        this.push = user.isPush();
-        this.snsType = user.getSnsType();
-        this.snsId = user.getSnsId();
-        this.privateRoomId = user.getPrivateRoomId();
-        this.profileImageUrl = user.getProfileImageUrl();
-        this.role = user.getRole();
-        this.deviceOs = user.getDeviceOs();
-        this.used = user.isUsed();
-
-        this.friendStatus = Objects.nonNull(friend)? friend.getStatus() : null;
-    }
 }

--- a/OurMemory_Server/src/main/java/com/kds/ourmemory/entity/notice/NoticeType.java
+++ b/OurMemory_Server/src/main/java/com/kds/ourmemory/entity/notice/NoticeType.java
@@ -1,8 +1,10 @@
 package com.kds.ourmemory.entity.notice;
 
+import io.swagger.annotations.ApiModel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+@ApiModel
 @Getter
 @AllArgsConstructor
 public enum NoticeType {

--- a/OurMemory_Server/src/test/java/com/kds/ourmemory/service/v1/todo/TodoServiceTest.java
+++ b/OurMemory_Server/src/test/java/com/kds/ourmemory/service/v1/todo/TodoServiceTest.java
@@ -38,7 +38,7 @@ class TodoServiceTest {
 
     @Test
     @Order(1)
-    @DisplayName("TODO 항목 생성")
+    @DisplayName("TODO 추가")
     @Transactional
     void insert() {
         /* 0-1. Set base data */
@@ -92,7 +92,7 @@ class TodoServiceTest {
 
     @Test
     @Order(3)
-    @DisplayName("TODO 리스트 조회")
+    @DisplayName("TODO 목록 조회")
     @Transactional
     void findTodos() {
         /* 0-1. Set base data */

--- a/OurMemory_Server/src/test/java/com/kds/ourmemory/service/v1/user/UserServiceTest.java
+++ b/OurMemory_Server/src/test/java/com/kds/ourmemory/service/v1/user/UserServiceTest.java
@@ -4,15 +4,14 @@ import com.kds.ourmemory.advice.v1.memory.exception.MemoryNotFoundException;
 import com.kds.ourmemory.advice.v1.room.exception.RoomNotFoundException;
 import com.kds.ourmemory.advice.v1.user.exception.UserNotFoundException;
 import com.kds.ourmemory.controller.v1.friend.dto.AcceptFriendDto;
-import com.kds.ourmemory.controller.v1.friend.dto.PatchFriendStatusDto;
 import com.kds.ourmemory.controller.v1.friend.dto.RequestFriendDto;
 import com.kds.ourmemory.controller.v1.memory.dto.InsertMemoryDto;
 import com.kds.ourmemory.controller.v1.room.dto.FindRoomsDto;
 import com.kds.ourmemory.controller.v1.room.dto.InsertRoomDto;
 import com.kds.ourmemory.controller.v1.user.dto.InsertUserDto;
 import com.kds.ourmemory.controller.v1.user.dto.PatchTokenDto;
-import com.kds.ourmemory.controller.v1.user.dto.UploadProfileImageDto;
 import com.kds.ourmemory.controller.v1.user.dto.UpdateUserDto;
+import com.kds.ourmemory.controller.v1.user.dto.UploadProfileImageDto;
 import com.kds.ourmemory.entity.friend.FriendStatus;
 import com.kds.ourmemory.entity.user.DeviceOs;
 import com.kds.ourmemory.service.v1.friend.FriendService;
@@ -84,7 +83,6 @@ class UserServiceTest {
         var insertRsp = userService.signUp(insertReq);
         assertThat(insertRsp).isNotNull();
         assertThat(insertRsp.getUserId()).isNotNull();
-        assertThat(insertRsp.getPrivateRoomId()).isNotNull();
     }
 
     @Test
@@ -199,189 +197,6 @@ class UserServiceTest {
     }
 
     @Test
-    @Order(6)
-    @DisplayName("사용자 목록 조회")
-    @Transactional
-    void findUsers() {
-        /* 0. Create Request */
-        var insertUniqueNameReq = new InsertUserDto.Request(
-                1, "TESTS_SNS_ID", "before pushToken",
-                "테스트 유저", "0720", true,
-                false, DeviceOs.ANDROID
-        );
-
-        var insertSameNameReq1 = new InsertUserDto.Request(
-                2, "TESTS_SNS_ID2", "before pushToken",
-                "동명이인", "0724", false,
-                true, DeviceOs.IOS
-        );
-
-        var insertSameNameReq2 = new InsertUserDto.Request(
-                3, "TESTS_SNS_ID3", "before pushToken",
-                "동명이인", "0720", true,
-                false, DeviceOs.ANDROID
-        );
-
-        /* 1. Insert */
-        var insertUniqueNameRsp = userService.signUp(insertUniqueNameReq);
-        assertThat(insertUniqueNameRsp).isNotNull();
-
-        var insertSameNameRsp1 = userService.signUp(insertSameNameReq1);
-        assertThat(insertSameNameRsp1).isNotNull();
-
-        var insertSameNameRsp2 = userService.signUp(insertSameNameReq2);
-        assertThat(insertSameNameRsp2).isNotNull();
-
-        /* 2. Find users before set friend */
-        // 1) find by id : insertUniqueNameReq
-        var findUsersByIdList1 = userService.findUsers(insertSameNameRsp1.getUserId(), insertUniqueNameRsp.getUserId(), null, null);
-        assertThat(findUsersByIdList1).isNotNull();
-        assertThat(findUsersByIdList1.isEmpty()).isFalse();
-        assertThat(findUsersByIdList1.size()).isOne();
-
-        var findUsersById1 = findUsersByIdList1.get(0);
-        assertThat(findUsersById1).isNotNull();
-        assertThat(findUsersById1.getUserId()).isEqualTo(insertUniqueNameRsp.getUserId());
-        assertThat(findUsersById1.getName()).isEqualTo(insertUniqueNameReq.getName());
-        assertThat(findUsersById1.isSolar()).isEqualTo(insertUniqueNameReq.isSolar());
-        assertThat(findUsersById1.isBirthdayOpen()).isEqualTo(insertUniqueNameReq.isBirthdayOpen());
-        assertThat(findUsersById1.getBirthday()).isEqualTo(insertUniqueNameReq.getBirthday());
-        assertThat(findUsersById1.getFriendStatus()).isNull();
-
-        // 2) find by id : insertSameNameReq1
-        var findUsersByIdList2 = userService.findUsers(insertUniqueNameRsp.getUserId(), insertSameNameRsp1.getUserId(), null, null);
-        assertThat(findUsersByIdList2).isNotNull();
-        assertThat(findUsersByIdList2.isEmpty()).isFalse();
-        assertThat(findUsersByIdList2.size()).isOne();
-
-        var findUsersById2 = findUsersByIdList2.get(0);
-        assertThat(findUsersById2).isNotNull();
-        assertThat(findUsersById2.getUserId()).isEqualTo(insertSameNameRsp1.getUserId());
-        assertThat(findUsersById2.getName()).isEqualTo(insertSameNameReq1.getName());
-        assertThat(findUsersById2.isSolar()).isEqualTo(insertSameNameReq1.isSolar());
-        assertThat(findUsersById2.isBirthdayOpen()).isEqualTo(insertSameNameReq1.isBirthdayOpen());
-        assertThat(findUsersById2.getBirthday()).isEqualTo(
-                insertSameNameReq1.isBirthdayOpen()? insertSameNameReq1.getBirthday() : null
-        );
-        assertThat(findUsersById2.getFriendStatus()).isNull();
-
-        // 3) find by id : insertSameNameReq2
-        var findUsersByIdList3 = userService.findUsers(insertSameNameRsp1.getUserId(), insertSameNameRsp2.getUserId(), null, null);
-        assertThat(findUsersByIdList3).isNotNull();
-        assertThat(findUsersByIdList3.isEmpty()).isFalse();
-        assertThat(findUsersByIdList3.size()).isOne();
-
-        var findUsersById3 = findUsersByIdList3.get(0);
-        assertThat(findUsersById3).isNotNull();
-        assertThat(findUsersById3.getUserId()).isEqualTo(insertSameNameRsp2.getUserId());
-        assertThat(findUsersById3.getName()).isEqualTo(insertSameNameReq2.getName());
-        assertThat(findUsersById3.isSolar()).isEqualTo(insertSameNameReq2.isSolar());
-        assertThat(findUsersById3.isBirthdayOpen()).isEqualTo(insertSameNameReq2.isBirthdayOpen());
-        assertThat(findUsersById3.getBirthday()).isEqualTo(insertSameNameReq2.getBirthday());
-        assertThat(findUsersById3.getFriendStatus()).isNull();
-
-        // 4) find by name : insertUniqueNameReq
-        var findUsersByUniqueNameList = userService.findUsers(insertSameNameRsp1.getUserId(), null, insertUniqueNameReq.getName(), null);
-        assertThat(findUsersByUniqueNameList).isNotNull();
-        assertThat(findUsersByUniqueNameList.isEmpty()).isFalse();
-        assertThat(findUsersByUniqueNameList.size()).isOne();
-
-        var findUsersByUniqueName = findUsersByUniqueNameList.get(0);
-        assertThat(findUsersByUniqueName).isNotNull();
-        assertThat(findUsersByUniqueName.getUserId()).isEqualTo(insertUniqueNameRsp.getUserId());
-        assertThat(findUsersByUniqueName.getName()).isEqualTo(insertUniqueNameReq.getName());
-        assertThat(findUsersByUniqueName.isSolar()).isEqualTo(insertUniqueNameReq.isSolar());
-        assertThat(findUsersByUniqueName.isBirthdayOpen()).isEqualTo(insertUniqueNameReq.isBirthdayOpen());
-        assertThat(findUsersByUniqueName.getBirthday()).isEqualTo(insertUniqueNameReq.getBirthday());
-        assertThat(findUsersByUniqueName.getFriendStatus()).isNull();
-
-        // 5) find by name : insertSameNameReq1 or 2
-        var findUsersBySameNameList = userService.findUsers(insertUniqueNameRsp.getUserId(), null, insertSameNameReq1.getName(), null);
-        assertThat(findUsersBySameNameList).isNotNull();
-        assertThat(findUsersBySameNameList.isEmpty()).isFalse();
-        assertThat(findUsersBySameNameList.size()).isEqualTo(2);
-        
-        for (var findUsersBySameName : findUsersBySameNameList) {
-            var findUsersBySameNameReq = findUsersBySameName.getUserId().equals(insertSameNameRsp1.getUserId()) ?
-                    insertSameNameReq1 : insertSameNameReq2;
-            var findUsersBySameNameId = findUsersBySameName.getUserId().equals(insertSameNameRsp1.getUserId()) ?
-                    insertSameNameRsp1.getUserId() : insertSameNameRsp2.getUserId();
-
-            assertThat(findUsersBySameName).isNotNull();
-            assertThat(findUsersBySameName.getUserId()).isEqualTo(findUsersBySameNameId);
-            assertThat(findUsersBySameName.getName()).isEqualTo(findUsersBySameNameReq.getName());
-            assertThat(findUsersBySameName.isSolar()).isEqualTo(findUsersBySameNameReq.isSolar());
-            assertThat(findUsersBySameName.isBirthdayOpen()).isEqualTo(findUsersBySameNameReq.isBirthdayOpen());
-            assertThat(findUsersBySameName.getBirthday()).isEqualTo(findUsersBySameNameReq.getBirthday());
-            assertThat(findUsersBySameName.getFriendStatus()).isNull();
-        }
-
-        /* 3. Set Friend Status */
-        // 1) WAIT - uniqueName -> sameName1, REQUESTED_BY - sameName1 -> uniqueName
-        var waitRequestFriendRsp = friendService.requestFriend(
-                new RequestFriendDto.Request(insertUniqueNameRsp.getUserId(), insertSameNameRsp1.getUserId())
-        );
-        assertThat(waitRequestFriendRsp).isNotNull();
-
-        // 2) FRIEND - uniqueName -> sameName2, BLOCK - sameName2 -> uniqueName
-        var friendRequestFriendRsp = friendService.requestFriend(
-                new RequestFriendDto.Request(insertUniqueNameRsp.getUserId(), insertSameNameRsp2.getUserId())
-        );
-        assertThat(friendRequestFriendRsp).isNotNull();
-
-        var friendAcceptFriendRsp = friendService.acceptFriend(
-                new AcceptFriendDto.Request(insertSameNameRsp2.getUserId(), insertUniqueNameRsp.getUserId())
-        );
-        assertThat(friendAcceptFriendRsp).isNotNull();
-
-        var blockFriendRsp = friendService.patchFriendStatus(
-                new PatchFriendStatusDto.Request(insertSameNameRsp2.getUserId(), insertUniqueNameRsp.getUserId(), FriendStatus.BLOCK)
-        );
-        assertThat(blockFriendRsp).isNotNull();
-
-        /* 4. Find users after set friend */
-        // 1) WAIT
-        var findUsersByWaitList = userService.findUsers(insertUniqueNameRsp.getUserId(), null, null, FriendStatus.WAIT);
-        assertThat(findUsersByWaitList).isNotNull();
-        assertThat(findUsersByWaitList.size()).isOne();
-
-        var findUsersByWaitRsp = findUsersByWaitList.get(0);
-        assertThat(findUsersByWaitRsp).isNotNull();
-        assertThat(findUsersByWaitRsp.getUserId()).isEqualTo(insertSameNameRsp1.getUserId());
-        assertThat(findUsersByWaitRsp.getFriendStatus()).isEqualTo(FriendStatus.WAIT);
-
-        // 2) REQUESTED_BY
-        var findUsersByRequestedByList = userService.findUsers(insertSameNameRsp1.getUserId(), null, null, FriendStatus.REQUESTED_BY);
-        assertThat(findUsersByRequestedByList).isNotNull();
-        assertThat(findUsersByRequestedByList.size()).isOne();
-
-        var findUsersByRequestedByRsp = findUsersByRequestedByList.get(0);
-        assertThat(findUsersByRequestedByRsp).isNotNull();
-        assertThat(findUsersByRequestedByRsp.getUserId()).isEqualTo(insertUniqueNameRsp.getUserId());
-        assertThat(findUsersByRequestedByRsp.getFriendStatus()).isEqualTo(FriendStatus.REQUESTED_BY);
-
-        // 3) FRIEND
-        var findUsersByFriendList = userService.findUsers(insertUniqueNameRsp.getUserId(), null, null, FriendStatus.FRIEND);
-        assertThat(findUsersByFriendList).isNotNull();
-        assertThat(findUsersByFriendList.size()).isOne();
-
-        var findUsersByFriendRsp = findUsersByFriendList.get(0);
-        assertThat(findUsersByFriendRsp).isNotNull();
-        assertThat(findUsersByFriendRsp.getUserId()).isEqualTo(insertSameNameRsp2.getUserId());
-        assertThat(findUsersByFriendRsp.getFriendStatus()).isEqualTo(FriendStatus.FRIEND);
-
-        // 4) BLOCK
-        var findUsersByBlockList = userService.findUsers(insertSameNameRsp2.getUserId(), null, null, FriendStatus.BLOCK);
-        assertThat(findUsersByBlockList).isNotNull();
-        assertThat(findUsersByBlockList.size()).isOne();
-
-        var findUsersByBlockRsp = findUsersByBlockList.get(0);
-        assertThat(findUsersByBlockRsp).isNotNull();
-        assertThat(findUsersByBlockRsp.getUserId()).isEqualTo(insertUniqueNameRsp.getUserId());
-        assertThat(findUsersByBlockRsp.getFriendStatus()).isEqualTo(FriendStatus.BLOCK);
-    }
-
-    @Test
     @Order(7)
     @DisplayName("사용자 삭제-친구")
     @Transactional
@@ -447,9 +262,6 @@ class UserServiceTest {
         assertThrows(
                 UserNotFoundException.class, () -> userService.find(userId)
         );
-
-        var findUsers = userService.findUsers(userId, null, null,  null);
-        assertTrue(findUsers.isEmpty());
 
         /* 3. Find friend from friendUser and check delete */
         var findFriendsFriendSide = friendService.findFriends(insertFriendUserRsp.getUserId());
@@ -519,9 +331,6 @@ class UserServiceTest {
         assertThrows(
                 UserNotFoundException.class, () -> userService.find(userId)
         );
-
-        var findUsers = userService.findUsers(userId, null, null,  null);
-        assertTrue(findUsers.isEmpty());
 
         /* 3. Find room and check delete */
         var roomId = insertUserRsp.getPrivateRoomId();
@@ -620,9 +429,6 @@ class UserServiceTest {
         assertThrows(
                 UserNotFoundException.class, () -> userService.find(userId)
         );
-
-        var findUsers = userService.findUsers(userId, null, null,  null);
-        assertTrue(findUsers.isEmpty());
 
         /* 3. Find room and check transfer owner */
         var findRoomRsp = roomService.find(insertOwnerRoomRsp.getRoomId());
@@ -732,9 +538,6 @@ class UserServiceTest {
         assertThrows(
                 UserNotFoundException.class, () -> userService.find(userId)
         );
-
-        var findUsers = userService.findUsers(userId, null, null,  null);
-        assertTrue(findUsers.isEmpty());
 
         /* 3. Find room and check member */
         var findRoomRsp = roomService.find(insertParticipantRoomRsp.getRoomId());


### PR DESCRIPTION
## #176 

## PR 설명
- 사용자 검색 기능 이관

## 변경된 내용
- 사용자 검색 기능을 아래와 같이 이관함
`사용자 API -> 친구 API`
- 사용자 검색 조건을 RequestBody 로 받도록 수정

## 추가적인 정보
- 요청 파라미터는 많지만 실제 사용되는 조건은 friendId, name, FriendStatus 만 사용된다.
- 다른 검색 조건 추가가 필요할 경우, 클라이언트 측과 협의하여 수정할 것.