### PR TITLE
Fix/#188 memory api request delete targetRoomId

### DIFF
--- a/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/memory/MemoryController.java
+++ b/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/memory/MemoryController.java
@@ -82,10 +82,11 @@ public class MemoryController {
             1. 공유방에서 삭제 -> 일정-방 관계 삭제\s
             2. 개인방에서 삭제 -> 일정 삭제 처리\s
             성공한 경우, 삭제 여부를 resultCode 로 전달하기 때문에 response=null 을 리턴한다.""")
-    @DeleteMapping("/{memoryId}")
+    @DeleteMapping("/{memoryId}/users/{userId}/rooms/{roomId}")
     public ApiResult<MemoryRspDto> delete(
-            @PathVariable long memoryId,
-            @RequestBody MemoryReqDto reqDto) {
-        return ok(memoryService.delete(memoryId, reqDto));
+            @ApiParam(value = "일정 번호") @PathVariable long memoryId,
+            @ApiParam(value = "일정을 삭제하려는 사용자 번호(개인방에서 삭제하는지 확인하기 위해 필요함.)") @PathVariable long userId,
+            @ApiParam(value = "일정이 삭제될 방 번호") @PathVariable long roomId) {
+        return ok(memoryService.delete(memoryId, userId, roomId));
     }
 }

--- a/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/memory/dto/MemoryReqDto.java
+++ b/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/memory/dto/MemoryReqDto.java
@@ -63,10 +63,6 @@ public class MemoryReqDto {
     @ApiModelProperty(value = "[일정 공유용] 대상 목록(공유 종류(ShareType) 에 맞춰 일정을 공유한다.)")
     private List<Long> shareIds;
 
-    /* Used only deleteMemory */
-    @ApiModelProperty(value = "[일정 삭제용] 일정을 삭제할 방 번호(일정이 여러방에 공유되기 때문에 삭제할 방 번호가 필요함.)")
-    private long targetRoomId;
-
     public Memory toEntity(User writer) {
         return Memory.builder()
                 .writer(writer)

--- a/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/room/RoomController.java
+++ b/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/room/RoomController.java
@@ -53,7 +53,7 @@ public class RoomController {
     @PutMapping("/{roomId}")
     public ApiResult<RoomRspDto> update(
         @PathVariable long roomId,
-        @RequestParam RoomReqDto reqDto
+        @RequestBody RoomReqDto reqDto
     ) {
         return ok(roomService.update(roomId, reqDto));
     }

--- a/OurMemory_Server/src/main/java/com/kds/ourmemory/service/v1/memory/MemoryService.java
+++ b/OurMemory_Server/src/main/java/com/kds/ourmemory/service/v1/memory/MemoryService.java
@@ -313,21 +313,21 @@ public class MemoryService {
     }
 
     @Transactional
-    public MemoryRspDto delete(long memoryId, MemoryReqDto reqDto) {
+    public MemoryRspDto delete(long memoryId, long userId, long roomId) {
         var memory = findMemory(memoryId)
                 .orElseThrow(
                         () -> new MemoryNotFoundException(String.format(NOT_FOUND_MESSAGE, MEMORY, memoryId))
                 );
 
-        findUser(reqDto.getUserId())
+        findUser(userId)
                 .map(user -> {
                     // 1. Delete memory from private room -> delete memory
-                    if (user.getPrivateRoomId() == reqDto.getTargetRoomId()) {
+                    if (user.getPrivateRoomId().equals(roomId)) {
                         memory.deleteMemory();
                     }
                     // 2. Delete memory from share room -> delete room-memory relation
                     else {
-                        findRoom(reqDto.getTargetRoomId())
+                        findRoom(roomId)
                                 .ifPresent(room -> {
                                     room.deleteMemory(memory);
                                     memory.deleteRoom(room);
@@ -337,7 +337,7 @@ public class MemoryService {
                     return true;
                 })
                 .orElseThrow(
-                        () -> new UserNotFoundException(String.format(NOT_FOUND_MESSAGE, USER, reqDto.getUserId()))
+                        () -> new UserNotFoundException(String.format(NOT_FOUND_MESSAGE, USER, userId))
                 );
 
         // delete response is null -> client already have data, so don't need response data.

--- a/OurMemory_Server/src/test/java/com/kds/ourmemory/service/v1/memory/MemoryServiceTest.java
+++ b/OurMemory_Server/src/test/java/com/kds/ourmemory/service/v1/memory/MemoryServiceTest.java
@@ -557,11 +557,6 @@ class MemoryServiceTest {
                 .bgColor("#FFFFFF")
                 .build();
 
-        var deleteMemoryReq = MemoryReqDto.builder()
-                .userId(insertWriterRsp.getUserId())
-                .targetRoomId(insertRoomRsp.getRoomId())
-                .build();
-
         /* 1. Make memory */
         var insertMemoryRsp = memoryService.insert(insertMemoryReq);
         assertThat(insertMemoryRsp).isNotNull();
@@ -582,7 +577,9 @@ class MemoryServiceTest {
         assertThat(findMemoriesRsp.getShareRooms().size()).isEqualTo(2);
 
         /* 3. Delete memory from share room */
-        var deleteRsp = memoryService.delete(insertMemoryRsp.getMemoryId(), deleteMemoryReq);
+        var deleteRsp = memoryService.delete(
+                insertMemoryRsp.getMemoryId(), insertWriterRsp.getUserId(), insertRoomRsp.getRoomId()
+        );
         assertNull(deleteRsp);
 
         /* 4. Find memory after delete */
@@ -620,11 +617,6 @@ class MemoryServiceTest {
                 .bgColor("#FFFFFF")
                 .build();
 
-        var deleteMemoryReq = MemoryReqDto.builder()
-                .userId(insertWriterRsp.getUserId())
-                .targetRoomId(insertWriterRsp.getPrivateRoomId())
-                .build();
-
         /* 1. Make memory */
         var insertMemoryRsp = memoryService.insert(insertMemoryReq);
         assertThat(insertMemoryRsp).isNotNull();
@@ -645,7 +637,9 @@ class MemoryServiceTest {
         assertThat(findMemoriesRsp.getShareRooms().size()).isEqualTo(2);
 
         /* 3. Delete memory from private room */
-        var deleteRsp = memoryService.delete(insertMemoryRsp.getMemoryId(), deleteMemoryReq);
+        var deleteRsp = memoryService.delete(
+                insertMemoryRsp.getMemoryId(), insertWriterRsp.getUserId(), insertWriterRsp.getPrivateRoomId()
+        );
         assertNull(deleteRsp);
 
         /* 4. Find memory after delete */


### PR DESCRIPTION
## #188 

## PR 설명
- 일정 기능 수정

## 변경된 내용
- 일정 삭제 시, PathVariable 로 파라미터를 받도록 수정
DELETE 요청 시 body 전달 시, 요청이 거절될 수 있다.
```
https://httpwg.org/specs/rfc7231.html#DELETE
  A payload within a DELETE request message has no defined semantics; sending a payload body on a DELETE request might cause some existing implementations to reject the request.
````
- 일정 요청 프로토콜에서 targetRoomId 삭제
  일정 삭제 전용 파라미터였기 때문에 삭제함.