### PR TITLE
Fix/#190 delete api request body to path variable

### DIFF
--- a/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/friend/FriendController.java
+++ b/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/friend/FriendController.java
@@ -23,7 +23,7 @@ public class FriendController {
     private final FriendService friendService;
 
     @ApiOperation(value = "사용자 검색", notes = "조건에 해당하는 사용자의 기본 정보와 친구 상태를 검색한다.")
-    @GetMapping(value = "/users/{userId}/search")
+    @GetMapping("/users/{userId}/search")
     public ApiResult<List<FriendRspDto>> findUsers(
             @PathVariable long userId,
             @ApiParam(value = "대상 사용자 번호") @RequestParam(required = false) Long targetId,
@@ -34,7 +34,7 @@ public class FriendController {
     }
 
     @ApiOperation(value = "친구 요청", notes = "사용자에게 친구 요청 푸시 알림을 전송한다. 차단한 상대에게는 요청이 전달되지 않는다.")
-    @PostMapping(value = "/reqDto")
+    @PostMapping("/request")
     public ApiResult<FriendRspDto> requestFriend(@RequestBody FriendReqDto reqDto) {
         return ok(friendService.requestFriend(reqDto));
     }
@@ -42,34 +42,37 @@ public class FriendController {
     @ApiOperation(value = "친구 요청 취소",
             notes = "친구 요청을 취소한 뒤, 요청보낸 사용자의 친구요청 알림을 삭제한다. " +
                     "성공한 경우, 실제 친구 데이터가 삭제되기 때문에 response=null 을 리턴한다.")
-    @DeleteMapping(value = "/cancel")
-    public ApiResult<FriendRspDto> cancelFriend(@RequestBody FriendReqDto reqDto) {
-        return ok(friendService.cancelFriend(reqDto));
+    @DeleteMapping("/cancel/users/{userId}/friendUsers/{friendUserId}")
+    public ApiResult<FriendRspDto> cancelFriend(
+            @ApiParam(value = "사용자 번호") @PathVariable long userId,
+            @ApiParam(value = "요청 취소할 사용자 번호") @PathVariable long friendUserId
+    ) {
+        return ok(friendService.cancelFriend(userId, friendUserId));
     }
 
     @ApiOperation(value = "친구 수락",
             notes = "친구 요청을 수락하고 친구를 추가한다. 요청을 수락한 사용자 알림 중 친구 요청 알림을 읽음처리한다."
     )
-    @PostMapping(value = "/accept")
+    @PostMapping("/accept")
     public ApiResult<FriendRspDto> acceptFriend(@RequestBody FriendReqDto reqDto) {
         return ok(friendService.acceptFriend(reqDto));
     }
 
     @ApiOperation(value = "친구 재 추가", notes = "친구 요청 후 상대방이 이미 친구인 경우, 내 쪽에서만 친구 추가를 진행한다.")
-    @PostMapping(value = "/reAdd")
+    @PostMapping("/reAdd")
     public ApiResult<FriendRspDto> reAddFriend(@RequestBody FriendReqDto reqDto) {
         return ok(friendService.reAddFriend(reqDto));
     }
 
     @ApiOperation(value = "친구 목록 조회", notes = "사용자의 친구 목록을 조회한다.")
-    @GetMapping(value = "/{userId}")
+    @GetMapping("/{userId}")
     public ApiResult<List<FriendRspDto>> findFriends(
             @ApiParam(value = "userId", required = true) @PathVariable long userId) {
         return ok(friendService.findFriends(userId));
     }
 
     @ApiOperation(value = "친구 상태 변경", notes = "친구 상태를 변경한다. 요청(WAIT)/수락 대기(REQUESTED_BY) 상태로는 변경할 수 없다.")
-    @PatchMapping(value = "/status")
+    @PatchMapping("/status")
     public ApiResult<FriendRspDto> patchFriendStatus(@RequestBody FriendReqDto reqDto) {
         return ok(friendService.patchFriendStatus(reqDto));
     }
@@ -77,8 +80,12 @@ public class FriendController {
     @ApiOperation(value = "친구 삭제", notes = """
             친구를 삭제한다. 내 쪽에서만 친구 삭제 처리한다.\s
             "성공한 경우, 실제 친구 데이터가 삭제되기 때문에 response=null 을 리턴한다.""")
-    @DeleteMapping
-    public ApiResult<FriendRspDto> deleteFriend(@RequestBody FriendReqDto reqDto) {
-        return ok(friendService.deleteFriend(reqDto));
+    @DeleteMapping("users/{userId}/friendUsers/{friendUserId}")
+    public ApiResult<FriendRspDto> deleteFriend(
+            @ApiParam(value = "사용자 번호") @PathVariable long userId,
+            @ApiParam(value = "친구 사용자 번호(삭제할 사용자 번호)") @PathVariable long friendUserId
+
+    ) {
+        return ok(friendService.deleteFriend(userId, friendUserId));
     }
 }

--- a/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/room/RoomController.java
+++ b/OurMemory_Server/src/main/java/com/kds/ourmemory/controller/v1/room/RoomController.java
@@ -5,6 +5,7 @@ import com.kds.ourmemory.controller.v1.room.dto.*;
 import com.kds.ourmemory.service.v1.room.RoomService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -26,7 +27,7 @@ public class RoomController {
     }
 
     @ApiOperation(value = "방 단일 조회")
-    @GetMapping(value = "/{roomId}")
+    @GetMapping("/{roomId}")
     public ApiResult<RoomRspDto> find(@PathVariable long roomId) {
         return ok(roomService.find(roomId));
     }
@@ -61,11 +62,11 @@ public class RoomController {
     @ApiOperation(value = "방 삭제", notes = """
             1. 개인방 -> 일정 삭제 후 방 삭제, 2. 공유방 -> 방만 삭제\s
             성공한 경우, 삭제 여부를 resultCode 로 전달하기 때문에 response=null 을 리턴한다.""")
-    @DeleteMapping(value = "/{roomId}")
+    @DeleteMapping("/{roomId}/users/{userId}")
     public ApiResult<RoomRspDto> delete(
             @PathVariable long roomId,
-            @RequestBody RoomReqDto reqDto
+            @ApiParam(value = "방 삭제할 사용자 번호") @PathVariable long userId
     ) {
-        return ok(roomService.delete(roomId, reqDto));
+        return ok(roomService.delete(roomId, userId));
     }
 }

--- a/OurMemory_Server/src/main/java/com/kds/ourmemory/service/v1/friend/FriendService.java
+++ b/OurMemory_Server/src/main/java/com/kds/ourmemory/service/v1/friend/FriendService.java
@@ -138,14 +138,14 @@ public class FriendService {
     }
 
     @Transactional
-    public FriendRspDto cancelFriend(FriendReqDto reqDto) {
+    public FriendRspDto cancelFriend(long userId, long friendUserId) {
         // Check my side
-        findFriend(reqDto.getUserId(), reqDto.getFriendUserId())
+        findFriend(userId, friendUserId)
                 .map(friend -> {
                     FriendStatus status = friend.getStatus();
                     if (status.equals(FriendStatus.FRIEND) || status.equals(FriendStatus.BLOCK)) {
                         throw new FriendInternalServerException(
-                                String.format(USER_ALREADY_FRIEND, reqDto.getFriendUserId())
+                                String.format(USER_ALREADY_FRIEND, friendUserId)
                         );
                     } else if (!FriendStatus.WAIT.equals(status)) {
                         throw new FriendStatusException(
@@ -159,12 +159,12 @@ public class FriendService {
                 })
                 .orElseThrow(
                         () -> new FriendNotFoundException(
-                                String.format(NOT_FOUND_FRIEND_MESSAGE, reqDto.getUserId(), reqDto.getFriendUserId())
+                                String.format(NOT_FOUND_FRIEND_MESSAGE, userId, friendUserId)
                         )
                 );
 
         // Check friend side And delete
-        findFriend(reqDto.getFriendUserId(), reqDto.getUserId())
+        findFriend(friendUserId, userId)
                 .map(friend -> {
                     FriendStatus status = friend.getStatus();
                     switch (status) {
@@ -184,7 +184,7 @@ public class FriendService {
                         case BLOCK -> {
                         }
                         case FRIEND -> throw new FriendInternalServerException(
-                                String.format(USER_ALREADY_FRIEND, reqDto.getUserId())
+                                String.format(USER_ALREADY_FRIEND, userId)
                         );
                         default -> throw new FriendStatusException(
                                 String.format(STATUS_ERROR_MESSAGE, FriendStatus.REQUESTED_BY, status)
@@ -195,7 +195,7 @@ public class FriendService {
                 })
                 .orElseThrow(
                         () -> new FriendNotFoundException(
-                                String.format(NOT_FOUND_FRIEND_MESSAGE, reqDto.getFriendUserId(), reqDto.getUserId())
+                                String.format(NOT_FOUND_FRIEND_MESSAGE, friendUserId, userId)
                         )
                 );
 
@@ -307,12 +307,12 @@ public class FriendService {
                 );
     }
 
-    public FriendRspDto deleteFriend(FriendReqDto reqDto) {
-        findFriend(reqDto.getUserId(), reqDto.getFriendUserId())
+    public FriendRspDto deleteFriend(long userId, long friendUserId) {
+        findFriend(userId, friendUserId)
                 .map(friend -> {
                     if (friend.getStatus().equals(FriendStatus.WAIT) || friend.getStatus().equals(FriendStatus.REQUESTED_BY))
                         throw new FriendInternalServerException(
-                                String.format("User '%d' is not friend. cancel reqDto plz.", reqDto.getFriendUserId())
+                                String.format("User '%d' is not friend. cancel reqDto plz.", friendUserId)
                         );
 
                     // Delete friend only my side. The other side does not delete.
@@ -320,7 +320,7 @@ public class FriendService {
                     return true;
                 })
                 .orElseThrow(() -> new FriendNotFoundFriendException(
-                                String.format(NOT_FOUND_FRIEND_MESSAGE, reqDto.getUserId(), reqDto.getFriendUserId())
+                                String.format(NOT_FOUND_FRIEND_MESSAGE, userId, friendUserId)
                         )
                 );
 

--- a/OurMemory_Server/src/main/java/com/kds/ourmemory/service/v1/room/RoomService.java
+++ b/OurMemory_Server/src/main/java/com/kds/ourmemory/service/v1/room/RoomService.java
@@ -198,11 +198,11 @@ public class RoomService {
     }
 
     @Transactional
-    public RoomRspDto delete(long roomId, RoomReqDto reqDto) {
-        var privateRoomId = findUser(reqDto.getUserId())
+    public RoomRspDto delete(long roomId, long userId) {
+        var privateRoomId = findUser(userId)
                 .map(User::getPrivateRoomId)
                 .orElseThrow(() -> new UserNotFoundException(
-                        String.format(NOT_FOUND_MESSAGE, USER, reqDto.getUserId())
+                        String.format(NOT_FOUND_MESSAGE, USER, userId)
                 ));
 
         findRoom(roomId)

--- a/OurMemory_Server/src/main/java/com/kds/ourmemory/service/v1/user/UserService.java
+++ b/OurMemory_Server/src/main/java/com/kds/ourmemory/service/v1/user/UserService.java
@@ -189,12 +189,7 @@ public class UserService {
 
                         // Related rooms - 3)
                         if (room.getId().longValue() == user.getPrivateRoomId()) {
-                            roomService.delete(
-                                    user.getPrivateRoomId(),
-                                    RoomReqDto.builder()
-                                            .userId(user.getId())
-                                            .build()
-                            );
+                            roomService.delete(user.getPrivateRoomId(), user.getId());
                         }
                     });
                     user.deleteRooms(user.getRooms());

--- a/OurMemory_Server/src/test/java/com/kds/ourmemory/service/v1/friend/FriendServiceTest.java
+++ b/OurMemory_Server/src/test/java/com/kds/ourmemory/service/v1/friend/FriendServiceTest.java
@@ -104,7 +104,7 @@ class FriendServiceTest {
         /* 3. Delete friend */
         // 1) Delete from my side
         var mySideDeleteRsp = friendService.deleteFriend(
-                new FriendReqDto(requestUserRsp.getUserId(), acceptUserRsp.getUserId())
+                requestUserRsp.getUserId(), acceptUserRsp.getUserId()
         );
         assertNull(mySideDeleteRsp);
 
@@ -123,7 +123,7 @@ class FriendServiceTest {
 
         // 2) Delete from friend side
         var friendSideDeleteRsp = friendService.deleteFriend(
-                new FriendReqDto(acceptUserRsp.getUserId(), requestUserRsp.getUserId())
+                acceptUserRsp.getUserId(), requestUserRsp.getUserId()
         );
         assertNull(friendSideDeleteRsp);
 
@@ -164,7 +164,7 @@ class FriendServiceTest {
         /* 0-5. Delete friend from my side */
         // Delete from requestUserRsp side
         var beforeMySideDeleteRsp = friendService.deleteFriend(
-                new FriendReqDto(requestUserRsp.getUserId(), acceptUserRsp.getUserId())
+                requestUserRsp.getUserId(), acceptUserRsp.getUserId()
         );
         assertNull(beforeMySideDeleteRsp);
 
@@ -222,7 +222,7 @@ class FriendServiceTest {
         /* 5. Delete friend */
         // 1) Delete from requestUserRsp side
         var mySideDeleteRsp = friendService.deleteFriend(
-                new FriendReqDto(requestUserRsp.getUserId(), acceptUserRsp.getUserId())
+                requestUserRsp.getUserId(), acceptUserRsp.getUserId()
         );
         assertNull(mySideDeleteRsp);
 
@@ -241,7 +241,7 @@ class FriendServiceTest {
 
         // 2) Delete from friend side
         var friendSideDeleteRsp = friendService.deleteFriend(
-                new FriendReqDto(acceptUserRsp.getUserId(), requestUserRsp.getUserId())
+                acceptUserRsp.getUserId(), requestUserRsp.getUserId()
         );
         assertNull(friendSideDeleteRsp);
 
@@ -267,7 +267,6 @@ class FriendServiceTest {
         var acceptReq = new FriendReqDto(acceptUserRsp.getUserId(), requestUserRsp.getUserId());
         var addReq = new FriendReqDto(requestUserRsp.getUserId(), acceptUserRsp.getUserId());
         var blockReq = new FriendReqDto(acceptUserRsp.getUserId(), requestUserRsp.getUserId(), FriendStatus.BLOCK);
-        var cancelReq = new FriendReqDto(requestUserRsp.getUserId(), acceptUserRsp.getUserId());
 
         /* 0-3. Request friend for other side friend */
         var beforeRequestRsp = friendService.requestFriend(requestReq);
@@ -284,7 +283,7 @@ class FriendServiceTest {
         /* 0-5. Delete friend from my side */
         // Delete from requestUserRsp side
         var beforeMySideDeleteRsp = friendService.deleteFriend(
-                new FriendReqDto(requestUserRsp.getUserId(), acceptUserRsp.getUserId())
+                requestUserRsp.getUserId(), acceptUserRsp.getUserId()
         );
         assertNull(beforeMySideDeleteRsp);
 
@@ -347,13 +346,14 @@ class FriendServiceTest {
 
         /* 5. Delete friend */
         // 1) Delete from user side
-        var userSideDeleteReqDto = new FriendReqDto(requestUserRsp.getUserId(), acceptUserRsp.getUserId());
+        var userSideUserId = requestUserRsp.getUserId();
+        var userSideFriendUserId = acceptUserRsp.getUserId();
         assertThrows(
-                FriendInternalServerException.class, () -> friendService.deleteFriend(userSideDeleteReqDto)
+                FriendInternalServerException.class, () -> friendService.deleteFriend(userSideUserId, userSideFriendUserId)
         );
 
         // Cancel friend request
-        var cancelRsp = friendService.cancelFriend(cancelReq);
+        var cancelRsp = friendService.cancelFriend(requestUserRsp.getUserId(), acceptUserRsp.getUserId());
         assertNull(cancelRsp);
 
         // Check my side
@@ -371,7 +371,7 @@ class FriendServiceTest {
 
         // 2) Delete from friend side
         var friendSideDeleteRsp = friendService.deleteFriend(
-                new FriendReqDto(acceptUserRsp.getUserId(), requestUserRsp.getUserId())
+                acceptUserRsp.getUserId(), requestUserRsp.getUserId()
         );
         assertNull(friendSideDeleteRsp);
 
@@ -412,7 +412,7 @@ class FriendServiceTest {
         /* 0-5. Delete requestUserRsp from friend side */
         // Delete requestUserRsp from friend
         var beforeMySideDeleteRsp = friendService.deleteFriend(
-                new FriendReqDto(acceptUserRsp.getUserId(), requestUserRsp.getUserId())
+                acceptUserRsp.getUserId(), requestUserRsp.getUserId()
         );
         assertNull(beforeMySideDeleteRsp);
 
@@ -464,7 +464,7 @@ class FriendServiceTest {
         /* 5. Delete friend */
         // 1) Delete from requestUserRsp side
         var mySideDeleteRsp = friendService.deleteFriend(
-                new FriendReqDto(requestUserRsp.getUserId(), acceptUserRsp.getUserId())
+                requestUserRsp.getUserId(), acceptUserRsp.getUserId()
         );
         assertNull(mySideDeleteRsp);
 
@@ -477,9 +477,11 @@ class FriendServiceTest {
         assertThat(deleteFromMySideFriendSideList.size()).isZero();
 
         // 2) Delete from friend side
-        var friendSideFriendReqDto = new FriendReqDto(acceptUserRsp.getUserId(), requestUserRsp.getUserId());
+        var friendSideUserId = acceptUserRsp.getUserId();
+        var friendSideFriendUserId = requestUserRsp.getUserId();
         assertThrows(
-                FriendNotFoundFriendException.class, () -> friendService.deleteFriend(friendSideFriendReqDto)
+                FriendNotFoundFriendException.class,
+                () -> friendService.deleteFriend(friendSideUserId, friendSideFriendUserId)
         );
 
         // Check my side
@@ -520,7 +522,7 @@ class FriendServiceTest {
         /* 0-5. Delete requestUserRsp from friend side */
         // Delete requestUserRsp from friend
         var beforeMySideDeleteRsp = friendService.deleteFriend(
-                new FriendReqDto(acceptUserRsp.getUserId(), requestUserRsp.getUserId())
+                acceptUserRsp.getUserId(), requestUserRsp.getUserId()
         );
         assertNull(beforeMySideDeleteRsp);
 
@@ -578,7 +580,7 @@ class FriendServiceTest {
         /* 4. Delete friend */
         // 1) Delete from requestUserRsp side
         var mySideDeleteRsp = friendService.deleteFriend(
-                new FriendReqDto(requestUserRsp.getUserId(), acceptUserRsp.getUserId())
+                requestUserRsp.getUserId(), acceptUserRsp.getUserId()
         );
         assertNull(mySideDeleteRsp);
 
@@ -591,9 +593,11 @@ class FriendServiceTest {
         assertThat(deleteFromMySideFriendSideList.size()).isZero();
 
         // 2) Delete from friend side
-        var friendSideFriendReqDto = new FriendReqDto(acceptUserRsp.getUserId(), requestUserRsp.getUserId());
+        var friendSideUserId = acceptUserRsp.getUserId();
+        var friendSideFriendUserId = requestUserRsp.getUserId();
         assertThrows(
-                FriendNotFoundFriendException.class, () -> friendService.deleteFriend(friendSideFriendReqDto)
+                FriendNotFoundFriendException.class,
+                () -> friendService.deleteFriend(friendSideUserId, friendSideFriendUserId)
         );
 
         // Check my side
@@ -664,7 +668,7 @@ class FriendServiceTest {
         /* 4. Delete friend */
         // 1) Delete from requestUserRsp side
         var mySideDeleteRsp = friendService.deleteFriend(
-                new FriendReqDto(requestUserRsp.getUserId(), acceptUserRsp.getUserId())
+                requestUserRsp.getUserId(), acceptUserRsp.getUserId()
         );
         assertNull(mySideDeleteRsp);
 
@@ -683,7 +687,7 @@ class FriendServiceTest {
 
         // 2) Delete from friend side
         var friendSideDeleteRsp = friendService.deleteFriend(
-                new FriendReqDto(acceptUserRsp.getUserId(), requestUserRsp.getUserId())
+                acceptUserRsp.getUserId(), requestUserRsp.getUserId()
         );
         assertNull(friendSideDeleteRsp);
 
@@ -749,7 +753,6 @@ class FriendServiceTest {
 
         /* 0-2. Create request */
         var requestReq = new FriendReqDto(requestUserRsp.getUserId(), acceptUserRsp.getUserId());
-        var cancelReq = new FriendReqDto(requestUserRsp.getUserId(), acceptUserRsp.getUserId());
 
         /* 1. Request friend */
         var requestRsp = friendService.requestFriend(requestReq);
@@ -767,7 +770,7 @@ class FriendServiceTest {
         assertFalse(beforeAcceptUserNoticeRsp.isRead());
 
         /* 3. Cancel friend request */
-        var cancelFriendRsp = friendService.cancelFriend(cancelReq);
+        var cancelFriendRsp = friendService.cancelFriend(requestUserRsp.getUserId(), acceptUserRsp.getUserId());
         assertNull(cancelFriendRsp);
 
         /* 4. Check notice after cancel */

--- a/OurMemory_Server/src/test/java/com/kds/ourmemory/service/v1/room/RoomServiceTest.java
+++ b/OurMemory_Server/src/test/java/com/kds/ourmemory/service/v1/room/RoomServiceTest.java
@@ -484,10 +484,6 @@ class RoomServiceTest {
                 .member(roomMembers)
                 .build();
 
-        var deleteRoomReq = RoomReqDto.builder()
-                .userId(insertOwnerRsp.getUserId())
-                .build();
-
         /* 1. Insert */
         var insertRoomRsp = roomService.insert(insertRoomReq);
         assertThat(insertRoomRsp.getOwnerId()).isEqualTo(insertOwnerRsp.getUserId());
@@ -541,7 +537,7 @@ class RoomServiceTest {
         assertThat(insertMemoryRspMember2.getAddedRoomId()).isEqualTo(insertMemoryReqMember2.getRoomId());
 
         /* 3. Delete share room */
-        var deleteRsp = roomService.delete(insertRoomRsp.getRoomId(), deleteRoomReq);
+        var deleteRsp = roomService.delete(insertRoomRsp.getRoomId(), insertOwnerRsp.getUserId());
         assertNull(deleteRsp);
 
         /* 4. Find room and memories after delete */
@@ -619,9 +615,6 @@ class RoomServiceTest {
                 .opened(false)
                 .member(roomMembers)
                 .build();
-        var deleteRoomReq = RoomReqDto.builder()
-                .userId(insertOwnerRsp.getUserId())
-                .build();
 
         /* 1. Insert */
         var insertRoomRsp = roomService.insert(insertRoomReq);
@@ -648,7 +641,7 @@ class RoomServiceTest {
         assertThat(insertMemoryRspOwner.getAddedRoomId()).isEqualTo(insertMemoryReqOwner.getRoomId());
 
         /* 3. Delete room */
-        var deleteRsp = roomService.delete(insertOwnerRsp.getPrivateRoomId(), deleteRoomReq);
+        var deleteRsp = roomService.delete(insertOwnerRsp.getPrivateRoomId(), insertOwnerRsp.getUserId());
         assertNull(deleteRsp);
 
         /* 4. Find room and memories after delete */


### PR DESCRIPTION
## #190 

## PR 설명
- DELETE 메소드를 사용하는 API 요청 파라미터 수정

## 변경된 내용
- 요청 파라미터를 URL 로 받도록 수정

## 추가적인 정보
- DELETE 메소드에 body 를 전달할 경우 요청 오류가 발생할 수 있다.

```
https://httpwg.org/specs/rfc7231.html#DELETE
  A payload within a DELETE request message has no defined semantics; sending a payload body on a DELETE request might cause some existing implementations to reject the request.
```