### PR TITLE
Fix/#209 find memories month filtering

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,11 +10,11 @@ name: Build
 
 on:
   workflow_dispatch:
-  push:
-    branches-ignore:
-      - 'develop'
-  pull_request:
-    branches: [develop]
+#  push:
+#    branches-ignore:
+#      - 'develop'
+#  pull_request:
+#    branches: [develop]
 
 jobs:
   build:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ name: Deploy to server
 
 on:
   push:
-    branches: [develop]
+    branches: [Feature/#198_github_action_deploy]
 
 jobs:
   build:

--- a/OurMemory_Server/src/main/java/com/kds/ourmemory/v1/config/Swagger2Config.java
+++ b/OurMemory_Server/src/main/java/com/kds/ourmemory/v1/config/Swagger2Config.java
@@ -25,7 +25,7 @@ public class Swagger2Config implements WebMvcConfigurer{
 	private ApiInfo apiInfo() {
 		return new ApiInfoBuilder()
 				.title("기억공유 앱 서비스 - 서버")
-				.version("0.0.1")
+				.version("0.0.2") // Major.Minor.Issue
 				.description("기억 공유 앱 서비스 API 서버")
 				.build();
 	}

--- a/OurMemory_Server/src/main/java/com/kds/ourmemory/v1/controller/memory/MemoryController.java
+++ b/OurMemory_Server/src/main/java/com/kds/ourmemory/v1/controller/memory/MemoryController.java
@@ -10,6 +10,7 @@ import io.swagger.annotations.ApiParam;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.YearMonth;
 import java.util.List;
 
 import static com.kds.ourmemory.v1.controller.ApiResult.ok;
@@ -36,13 +37,25 @@ public class MemoryController {
         return ok(memoryService.find(memoryId, roomId));
     }
 
-    @ApiOperation(value = "일정 목록 조회", notes = "조건에 맞는 일정을 검색한다. 일정 시작시간 -> 일정 생성시간 순으로 정렬된다.")
+    @ApiOperation(value = "일정 목록 조회", notes = """
+            아래 조건에 맞는 일정 목록을 검색한다.
+            1. 검색기간 - 전달 시, 사이 값으로 조회
+                1) 시작월(yyyy-MM)
+                2) 종료월(yyyy-MM)
+            2. 검색조건 - 각 조건 별 OR 검색, Equals 검색
+                1) 일정 작성자 번호
+                2) 일정 제목
+            3. 정렬조건 - 오름차순
+                1) 일정 시작시간
+                2) 일정 생성시간""")
     @GetMapping
     public ApiResult<List<MemoryRspDto>> findMemories(
             @ApiParam(value = "일정 작성자 번호") @RequestParam(required = false) Long writerId,
-            @ApiParam(value = "일정 제목") @RequestParam(required = false) String name
+            @ApiParam(value = "일정 제목") @RequestParam(required = false) String name,
+            @ApiParam(value = "일정 시작월", example = "yyyy-MM") @RequestParam(required = false) YearMonth startMonth,
+            @ApiParam(value = "일정 종료월", example = "yyyy-MM") @RequestParam(required = false) YearMonth endMonth
     ) {
-        return ok(memoryService.findMemories(writerId, name));
+        return ok(memoryService.findMemories(writerId, name, startMonth, endMonth));
     }
 
     @ApiOperation(value = "일정 수정", notes = "전달받은 값이 있는 경우 수정")
@@ -63,10 +76,10 @@ public class MemoryController {
 
     @ApiOperation(value = "일정 공유",
             notes = """
-                    사용자가 대상 목록에게 일정을 공유시킨다.\s
-                    1. 사용자 개별 공유: 각 사용자 별로 방 생성 뒤 일정 공유(type=USERS, targetIds=사용자 번호 목록)\s
-                    2. 사용자 그룹 공유: 사용자들을 참여자로 방 생성 후 일정 공유(type=USER_GROUP, targetIds=사용자 번호 목록)\s
-                    3. 기존 방에 공유: 전달받은 각각의 방에 일정 공유(type=ROOMS, targetIds=방 번호 목록)"""
+                    ""                    사용자가 대상 목록에게 일정을 공유시킨다.\s
+                                        1. 사용자 개별 공유: 각 사용자 별로 방 생성 뒤 일정 공유(type=USERS, targetIds=사용자 번호 목록)\s
+                                        2. 사용자 그룹 공유: 사용자들을 참여자로 방 생성 후 일정 공유(type=USER_GROUP, targetIds=사용자 번호 목록)\s
+                                        3. 기존 방에 공유: 전달받은 각각의 방에 일정 공유(type=ROOMS, targetIds=방 번호 목록)"""
     )
     @PostMapping("/{memoryId}/share/{userId}")
     public ApiResult<MemoryRspDto> shareMemory(

--- a/OurMemory_Server/src/main/java/com/kds/ourmemory/v1/entity/memory/Memory.java
+++ b/OurMemory_Server/src/main/java/com/kds/ourmemory/v1/entity/memory/Memory.java
@@ -13,6 +13,7 @@ import javax.persistence.*;
 import java.io.Serial;
 import java.io.Serializable;
 import java.time.LocalDateTime;
+import java.time.YearMonth;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -131,6 +132,56 @@ public class Memory extends BaseTimeEntity implements Serializable {
 
     public void deleteRoom(Room room) {
         this.rooms.remove(room);
+    }
+
+    /**
+     * Check start <= endDate
+     *   ref) start null -> true(None filtered.)
+     *
+     * @param start filtering option
+     * @return boolean start <= endDate
+     */
+    public boolean isAfter(YearMonth start) {
+        if (Objects.isNull(start)) return true;
+
+        var targetYear = endDate.getYear();
+        var targetMonth = endDate.getMonthValue();
+
+        var filterYear = start.getYear();
+        var filterMonth = start.getMonthValue();
+
+        // 1. Before Year
+        if (targetYear < filterYear) {
+            return false;
+        }
+
+        // 2. Same year -> before month
+        return targetYear != filterYear || targetMonth >= filterMonth;
+    }
+
+    /**
+     * Check startDate <= end
+     *   ref) end null -> true(None filtered.)
+     *
+     * @param end filtering option
+     * @return boolean startDate <= end
+     */
+    public boolean isBefore(YearMonth end) {
+        if (Objects.isNull(end)) return true;
+
+        var targetYear = startDate.getYear();
+        var targetMonth = startDate.getMonthValue();
+
+        var filterYear = end.getYear();
+        var filterMonth = end.getMonthValue();
+
+        // 1. After Year
+        if (targetYear > filterYear) {
+            return false;
+        }
+
+        // 2. Same year -> after month
+        return targetYear != filterYear || targetMonth <= filterMonth;
     }
 
     @Override

--- a/OurMemory_Server/src/test/java/com/kds/ourmemory/v1/controller/memory/MemoryControllerTest.java
+++ b/OurMemory_Server/src/test/java/com/kds/ourmemory/v1/controller/memory/MemoryControllerTest.java
@@ -18,6 +18,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
+import java.time.YearMonth;
 import java.time.format.DateTimeFormatter;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -35,6 +36,7 @@ class MemoryControllerTest {
     private final ObjectMapper mapper = new ObjectMapper().registerModule(new JavaTimeModule());
 
     private final DateTimeFormatter alertTimeFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+    private final DateTimeFormatter dateFormat = DateTimeFormatter.ofPattern("yyyy-MM");
 
     @Mock
     MemoryService memoryService;
@@ -44,7 +46,7 @@ class MemoryControllerTest {
 
     @Test
     @DisplayName("일정 목록 조회 요청-응답 | 성공")
-    void findMemoriesSuccess() throws JsonProcessingException{
+    void findMemoriesSuccess() throws JsonProcessingException {
         // given
         var writer = User.builder()
                 .id(1L)
@@ -118,16 +120,23 @@ class MemoryControllerTest {
         var memories = Stream.of(memory1, memory2, memory3).map(MemoryRspDto::new)
                 .collect(Collectors.toList());
 
+        var startMonth = YearMonth.parse(
+                YearMonth.now().minusMonths(1).format(dateFormat), dateFormat);
+        var endMonth = YearMonth.parse(
+                YearMonth.now().plusMonths(1).format(dateFormat), dateFormat);
+
         // when
-        when(memoryService.findMemories(writer.getId(), null)).thenReturn(memories);
+        when(memoryService.findMemories(writer.getId(), null, startMonth, endMonth)).thenReturn(memories);
 
         // then
-        var responseDto = memoryController.findMemories(writer.getId(), null);
+        var responseDto = memoryController
+                .findMemories(writer.getId(), null, startMonth, endMonth);
+
         assertThat(responseDto.getResultCode()).isEqualTo("S001");
         assertThat(responseDto.getResponse().size()).isEqualTo(3);
 
         // check response data
         log.debug(mapper.writerWithDefaultPrettyPrinter().writeValueAsString(responseDto));
     }
-    
+
 }

--- a/OurMemory_Server/src/test/java/com/kds/ourmemory/v1/service/memory/MemoryServiceTest.java
+++ b/OurMemory_Server/src/test/java/com/kds/ourmemory/v1/service/memory/MemoryServiceTest.java
@@ -20,7 +20,9 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.time.LocalDateTime;
+import java.time.YearMonth;
 import java.time.format.DateTimeFormatter;
+import java.time.temporal.TemporalAdjusters;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -43,6 +45,7 @@ class MemoryServiceTest {
      * This is because time difference occurs after room creation due to relation table work.
      */
     private DateTimeFormatter alertTimeFormat;  // startTime, endTime, firstAlarm, secondAlarm format
+    private DateTimeFormatter dateFormat;
 
     // Base data for test memoryService
     private UserRspDto insertWriterRsp;
@@ -63,6 +66,7 @@ class MemoryServiceTest {
     @BeforeAll
     void setUp() {
         alertTimeFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+        dateFormat = DateTimeFormatter.ofPattern("yyyy-MM");
     }
 
     @Test
@@ -2268,7 +2272,7 @@ class MemoryServiceTest {
 
         /* 3. Check delete memory */
         // 1) Find memory from writer
-        var findMemoriesRsp = memoryService.findMemories(insertMemoryRsp.getWriterId(), null);
+        var findMemoriesRsp = memoryService.findMemories(insertMemoryRsp.getWriterId(), null, null, null);
         assertThat(findMemoriesRsp.size()).isOne();
         assertThat(findMemoriesRsp.get(0).getMemoryId()).isEqualTo(insertMemoryRsp.getMemoryId());
 
@@ -2328,7 +2332,7 @@ class MemoryServiceTest {
 
         /* 3. Check delete memory */
         // 1) Find memory from writer
-        var findMemoriesRsp = memoryService.findMemories(insertMemoryRsp.getWriterId(), null);
+        var findMemoriesRsp = memoryService.findMemories(insertMemoryRsp.getWriterId(), null, null, null);
         assertThat(findMemoriesRsp.size()).isOne();
         assertThat(findMemoriesRsp.get(0).getMemoryId()).isEqualTo(insertMemoryRsp.getMemoryId());
 
@@ -2387,7 +2391,7 @@ class MemoryServiceTest {
 
         /* 3. Check delete memory */
         // 1) Find memory from writer
-        var findMemoriesRsp = memoryService.findMemories(insertMemoryRsp.getWriterId(), null);
+        var findMemoriesRsp = memoryService.findMemories(insertMemoryRsp.getWriterId(), null, null, null);
         assertThat(findMemoriesRsp.size()).isOne();
         assertThat(findMemoriesRsp.get(0).getMemoryId()).isEqualTo(insertMemoryRsp.getMemoryId());
 
@@ -2446,7 +2450,7 @@ class MemoryServiceTest {
 
         /* 3. Check delete memory */
         // 1) Find memory from writer
-        var findMemoriesRsp = memoryService.findMemories(insertMemoryRsp.getWriterId(), null);
+        var findMemoriesRsp = memoryService.findMemories(insertMemoryRsp.getWriterId(), null, null, null);
         assertThat(findMemoriesRsp.size()).isOne();
         assertThat(findMemoriesRsp.get(0).getMemoryId()).isEqualTo(insertMemoryRsp.getMemoryId());
 
@@ -2516,7 +2520,7 @@ class MemoryServiceTest {
 
         /* 3. Check delete memory */
         // 1) Find memory from writer
-        var findMemoriesRsp = memoryService.findMemories(insertMemoryRsp.getWriterId(), null);
+        var findMemoriesRsp = memoryService.findMemories(insertMemoryRsp.getWriterId(), null, null, null);
         assertThat(findMemoriesRsp.size()).isOne();
         assertThat(findMemoriesRsp.get(0).getMemoryId()).isEqualTo(insertMemoryRsp.getMemoryId());
 
@@ -2572,7 +2576,7 @@ class MemoryServiceTest {
 
         /* 3. Check delete memory */
         // 1) Find memory from writer
-        var findMemoriesRsp = memoryService.findMemories(insertMemoryRsp.getWriterId(), null);
+        var findMemoriesRsp = memoryService.findMemories(insertMemoryRsp.getWriterId(), null, null, null);
         assertThat(findMemoriesRsp.size()).isZero();
 
         // 2) Find memory from inserted room
@@ -2629,7 +2633,7 @@ class MemoryServiceTest {
 
         /* 3. Check delete memory */
         // 1) Find memory from writer
-        var findMemoriesRsp = memoryService.findMemories(insertMemoryRsp.getWriterId(), null);
+        var findMemoriesRsp = memoryService.findMemories(insertMemoryRsp.getWriterId(), null, null, null);
         assertThat(findMemoriesRsp.size()).isOne();
         assertThat(findMemoriesRsp.get(0).getMemoryId()).isEqualTo(insertMemoryRsp.getMemoryId());
 
@@ -2687,7 +2691,7 @@ class MemoryServiceTest {
 
         /* 3. Check delete memory */
         // 1) Find memory from writer
-        var findMemoriesRsp = memoryService.findMemories(insertMemoryRsp.getWriterId(), null);
+        var findMemoriesRsp = memoryService.findMemories(insertMemoryRsp.getWriterId(), null, null, null);
         assertThat(findMemoriesRsp.size()).isOne();
         assertThat(findMemoriesRsp.get(0).getMemoryId()).isEqualTo(insertMemoryRsp.getMemoryId());
 
@@ -2745,7 +2749,7 @@ class MemoryServiceTest {
 
         /* 3. Check delete memory */
         // 1) Find memory from writer
-        var findMemoriesRsp = memoryService.findMemories(insertMemoryRsp.getWriterId(), null);
+        var findMemoriesRsp = memoryService.findMemories(insertMemoryRsp.getWriterId(), null, null, null);
         assertThat(findMemoriesRsp.size()).isOne();
         assertThat(findMemoriesRsp.get(0).getMemoryId()).isEqualTo(insertMemoryRsp.getMemoryId());
 
@@ -2814,7 +2818,7 @@ class MemoryServiceTest {
 
         /* 3. Check delete memory */
         // 1) Find memory from writer
-        var findMemoriesRsp = memoryService.findMemories(insertMemoryRsp.getWriterId(), null);
+        var findMemoriesRsp = memoryService.findMemories(insertMemoryRsp.getWriterId(), null, null, null);
         assertThat(findMemoriesRsp.size()).isOne();
         assertThat(findMemoriesRsp.get(0).getMemoryId()).isEqualTo(insertMemoryRsp.getMemoryId());
 
@@ -3345,8 +3349,8 @@ class MemoryServiceTest {
     }
 
     @Test
-    @DisplayName("일정 목록 조회 | 성공")
-    void findMemoriesSuccess() {
+    @DisplayName("일정 목록 조회 -> 전체기간 | 성공")
+    void findAllMemoriesSuccess() {
         /* 0-1. Set base data */
         setBaseData();
 
@@ -3500,7 +3504,7 @@ class MemoryServiceTest {
         assertThat(insertMemoryRsp7).isNotNull();
 
         /* 2. Find memories */
-        List<MemoryRspDto> findMemoriesList = memoryService.findMemories(insertMemoryReq1.getUserId(), null);
+        List<MemoryRspDto> findMemoriesList = memoryService.findMemories(insertMemoryReq1.getUserId(), null, null, null);
         assertThat(findMemoriesList.size()).isEqualTo(7);
 
         // expected order: 3 5 2 4 6 1 7
@@ -3524,6 +3528,281 @@ class MemoryServiceTest {
 
         var findMemoriesRsp7 = findMemoriesList.get(6);
         assertThat(findMemoriesRsp7.getMemoryId()).isEqualTo(insertMemoryRsp7.getMemoryId());
+    }
+
+    @Test
+    @DisplayName("일정 목록 조회 -> 월 범위 | 성공")
+    void findMonthsMemoriesSuccess() {
+        /* 0-1. Set base data */
+        setBaseData();
+
+        /* 0-2. Create request */
+        var now = LocalDateTime.now();
+
+        // 1) -2 Month last Day 00H:00M ~ -2 Month last Day 23H:59M | Edge case, Out of range
+        var insertMemoryReq1 = MemoryReqDto.builder()
+                .userId(insertWriterRsp.getUserId())
+                .roomId(insertRoomRsp.getRoomId())
+                .name("Test Memory1")
+                .contents("Test Contents")
+                .place("Test Place")
+                .startDate(LocalDateTime.parse(
+                        LocalDateTime.of(
+                                now.minusMonths(2).getYear(),
+                                now.minusMonths(2).getMonthValue(),
+                                now.minusMonths(2).with(TemporalAdjusters.lastDayOfMonth()).getDayOfMonth(),
+                                0,
+                                0).format(alertTimeFormat),
+                        alertTimeFormat)
+                ) // 시작시간
+                .endDate(LocalDateTime.parse(
+                        LocalDateTime.of(
+                                now.minusMonths(2).getYear(),
+                                now.minusMonths(2).getMonthValue(),
+                                now.minusMonths(2).with(TemporalAdjusters.lastDayOfMonth()).getDayOfMonth(),
+                                23,
+                                59).format(alertTimeFormat),
+                        alertTimeFormat)
+                ) // 종료시간
+                .firstAlarm(LocalDateTime.parse(
+                        LocalDateTime.now().minusMonths(2).plusDays(6).format(alertTimeFormat), alertTimeFormat)
+                ) // 첫 번째 알림
+                .bgColor("#FFFFFF")
+                .build();
+
+        // 2) -1 Month 1 Day 00H:00M ~ -1 Month 8 Day 14H:00M
+        var insertMemoryReq2 = MemoryReqDto.builder()
+                .userId(insertWriterRsp.getUserId())
+                .roomId(insertRoomRsp.getRoomId())
+                .name("Test Memory3")
+                .contents("Test Contents")
+                .place("Test Place")
+                .startDate(LocalDateTime.parse(
+                        LocalDateTime.of(
+                                now.minusMonths(1).getYear(),
+                                now.minusMonths(1).getMonthValue(),
+                                1,
+                                0,
+                                0).format(alertTimeFormat),
+                        alertTimeFormat)
+                ) // 시작시간
+                .endDate(LocalDateTime.parse(
+                        LocalDateTime.of(
+                                now.minusMonths(1).getYear(),
+                                now.minusMonths(1).getMonthValue(),
+                                8,
+                                14,
+                                0).format(alertTimeFormat),
+                        alertTimeFormat)
+                ) // 종료시간
+                .firstAlarm(LocalDateTime.parse(
+                        LocalDateTime.now().minusMonths(2).plusDays(1).format(alertTimeFormat), alertTimeFormat)
+                ) // 첫 번째 알림
+                .bgColor("#FFFFFF")
+                .build();
+
+        // 3) -2 Month 20 Day 00H:00M ~ -1 Month 1 Day 00H:00M | Edge case
+        var insertMemoryReq3 = MemoryReqDto.builder()
+                .userId(insertWriterRsp.getUserId())
+                .roomId(insertRoomRsp.getRoomId())
+                .name("Test Memory2")
+                .contents("Test Contents")
+                .place("Test Place")
+                .startDate(LocalDateTime.parse(
+                        LocalDateTime.of(
+                                now.minusMonths(2).getYear(),
+                                now.minusMonths(2).getMonthValue(),
+                                20,
+                                0,
+                                0).format(alertTimeFormat),
+                        alertTimeFormat)
+                ) // 시작시간
+                .endDate(LocalDateTime.parse(
+                        LocalDateTime.of(
+                                now.minusMonths(1).getYear(),
+                                now.minusMonths(1).getMonthValue(),
+                                1,
+                                0,
+                                0).format(alertTimeFormat),
+                        alertTimeFormat)
+                ) // 종료시간
+                .firstAlarm(LocalDateTime.parse(
+                        LocalDateTime.now().minusMonths(1).plusDays(5).format(alertTimeFormat), alertTimeFormat)
+                ) // 첫 번째 알림
+                .bgColor("#FFFFFF")
+                .build();
+
+        // 4) now Month now Day 00H:00M ~ now Month now Day 01H:00M | Same case to 5), Early insert
+        var insertMemoryReq4 = MemoryReqDto.builder()
+                .userId(insertWriterRsp.getUserId())
+                .roomId(insertRoomRsp.getRoomId())
+                .name("Test Memory4")
+                .contents("Test Contents")
+                .place("Test Place")
+                .startDate(LocalDateTime.parse(
+                        LocalDateTime.of(
+                                now.getYear(),
+                                now.getMonthValue(),
+                                now.getDayOfMonth(),
+                                0,
+                                0).format(alertTimeFormat),
+                        alertTimeFormat)
+                ) // 시작시간
+                .endDate(LocalDateTime.parse(
+                        LocalDateTime.of(
+                                now.getYear(),
+                                now.getMonthValue(),
+                                now.getDayOfMonth(),
+                                1,
+                                0).format(alertTimeFormat),
+                        alertTimeFormat)
+                ) // 종료시간
+                .firstAlarm(LocalDateTime.parse(
+                        LocalDateTime.now().plusDays(4).format(alertTimeFormat), alertTimeFormat)
+                ) // 첫 번째 알림
+                .bgColor("#FFFFFF")
+                .build();
+
+        // 5) now Month now Day 00H:00M ~ now Month now Day 01H:00M | Same case to 4), Rate insert
+        var insertMemoryReq5 = MemoryReqDto.builder()
+                .userId(insertWriterRsp.getUserId())
+                .roomId(insertRoomRsp.getRoomId())
+                .name("Test Memory1")
+                .contents("Test Contents")
+                .place("Test Place")
+                .startDate(LocalDateTime.parse(
+                                LocalDateTime.of(
+                                        now.getYear(),
+                                        now.getMonthValue(),
+                                        now.getDayOfMonth(),
+                                        0,
+                                        0).format(alertTimeFormat),
+                                alertTimeFormat)
+                ) // 시작시간
+                .endDate(LocalDateTime.parse(
+                                LocalDateTime.of(
+                                        now.getYear(),
+                                        now.getMonthValue(),
+                                        now.getDayOfMonth(),
+                                        1,
+                                        0).format(alertTimeFormat),
+                                alertTimeFormat)
+                ) // 종료시간
+                .firstAlarm(LocalDateTime.parse(
+                        LocalDateTime.now().plusMonths(1).plusDays(1).format(alertTimeFormat), alertTimeFormat)
+                ) // 첫 번째 알림
+                .bgColor("#FFFFFF")
+                .build();
+
+        // 6) +2 Month 1 Day 00H:00M ~ +2 Month 1 Day 01H:00M | Edge case, Out of range
+        var insertMemoryReq6 = MemoryReqDto.builder()
+                .userId(insertWriterRsp.getUserId())
+                .roomId(insertRoomRsp.getRoomId())
+                .name("Test Memory6")
+                .contents("Test Contents")
+                .place("Test Place")
+                .startDate(LocalDateTime.parse(
+                        LocalDateTime.of(
+                                now.plusMonths(2).getYear(),
+                                now.plusMonths(2).getMonthValue(),
+                                1,
+                                0,
+                                0).format(alertTimeFormat),
+                        alertTimeFormat)
+                ) // 시작시간
+                .endDate(LocalDateTime.parse(
+                        LocalDateTime.of(
+                                now.plusMonths(2).getYear(),
+                                now.plusMonths(2).getMonthValue(),
+                                1,
+                                1,
+                                0).format(alertTimeFormat),
+                        alertTimeFormat)
+                ) // 종료시간
+                .firstAlarm(LocalDateTime.parse(
+                        LocalDateTime.now().plusMonths(1).plusDays(3).format(alertTimeFormat), alertTimeFormat)
+                ) // 첫 번째 알림
+                .bgColor("#FFFFFF")
+                .build();
+
+        // 7) +1 Month last Day 23H:59M ~ +2 Month 1 Day 06H:00M | Edge case
+        var insertMemoryReq7 = MemoryReqDto.builder()
+                .userId(insertWriterRsp.getUserId())
+                .roomId(insertRoomRsp.getRoomId())
+                .name("Test Memory7")
+                .contents("Test Contents")
+                .place("Test Place")
+                .startDate(LocalDateTime.parse(
+                        LocalDateTime.of(
+                                now.plusMonths(1).getYear(),
+                                now.plusMonths(1).getMonthValue(),
+                                now.plusMonths(1).with(TemporalAdjusters.lastDayOfMonth()).getDayOfMonth(),
+                                23,
+                                59).format(alertTimeFormat),
+                        alertTimeFormat)
+                ) // 시작시간
+                .endDate(LocalDateTime.parse(
+                        LocalDateTime.of(
+                                now.plusMonths(2).getYear(),
+                                now.plusMonths(2).getMonthValue(),
+                                1,
+                                6,
+                                0).format(alertTimeFormat),
+                        alertTimeFormat)
+                ) // 종료시간
+                .firstAlarm(LocalDateTime.parse(
+                        LocalDateTime.now().plusMonths(1).plusDays(2).format(alertTimeFormat), alertTimeFormat)
+                ) // 첫 번째 알림
+                .bgColor("#FFFFFF")
+                .build();
+
+        /* 1. Make memories */
+        var insertMemoryRsp1 = memoryService.insert(insertMemoryReq1);
+        assertThat(insertMemoryRsp1).isNotNull();
+
+        var insertMemoryRsp2 = memoryService.insert(insertMemoryReq2);
+        assertThat(insertMemoryRsp2).isNotNull();
+
+        var insertMemoryRsp3 = memoryService.insert(insertMemoryReq3);
+        assertThat(insertMemoryRsp3).isNotNull();
+
+        var insertMemoryRsp4 = memoryService.insert(insertMemoryReq4);
+        assertThat(insertMemoryRsp4).isNotNull();
+
+        var insertMemoryRsp5 = memoryService.insert(insertMemoryReq5);
+        assertThat(insertMemoryRsp5).isNotNull();
+
+        var insertMemoryRsp6 = memoryService.insert(insertMemoryReq6);
+        assertThat(insertMemoryRsp6).isNotNull();
+
+        var insertMemoryRsp7 = memoryService.insert(insertMemoryReq7);
+        assertThat(insertMemoryRsp7).isNotNull();
+
+        /* 2. Find memories */
+        var startMonth = YearMonth.parse(
+                YearMonth.now().minusMonths(1).format(dateFormat), dateFormat);
+        var endMonth = YearMonth.parse(
+                YearMonth.now().plusMonths(1).format(dateFormat), dateFormat);
+        var findMemoriesList = memoryService.findMemories(
+                insertMemoryReq1.getUserId(), null, startMonth, endMonth
+        );
+        assertThat(findMemoriesList.size()).isEqualTo(5);
+
+        // Expected order: 3 2 4 5 7(Out of range: 1, 6)
+        var findMemoriesRsp1 = findMemoriesList.get(0);
+        assertThat(findMemoriesRsp1.getMemoryId()).isEqualTo(insertMemoryRsp3.getMemoryId());
+
+        var findMemoriesRsp2 = findMemoriesList.get(1);
+        assertThat(findMemoriesRsp2.getMemoryId()).isEqualTo(insertMemoryRsp2.getMemoryId());
+
+        var findMemoriesRsp3 = findMemoriesList.get(2);
+        assertThat(findMemoriesRsp3.getMemoryId()).isEqualTo(insertMemoryRsp4.getMemoryId());
+
+        var findMemoriesRsp4 = findMemoriesList.get(3);
+        assertThat(findMemoriesRsp4.getMemoryId()).isEqualTo(insertMemoryRsp5.getMemoryId());
+
+        var findMemoriesRsp5 = findMemoriesList.get(4);
+        assertThat(findMemoriesRsp5.getMemoryId()).isEqualTo(insertMemoryRsp7.getMemoryId());
     }
 
     // life cycle: @Before -> @Test => separate => Not maintained 
@@ -3570,4 +3849,5 @@ class MemoryServiceTest {
         assertThat(insertRoomRsp.getOwnerId()).isEqualTo(insertWriterRsp.getUserId());
         assertThat(insertRoomRsp.getMembers().size()).isEqualTo(2);
     }
+
 }

--- a/OurMemory_Server/src/test/java/com/kds/ourmemory/v1/service/room/RoomServiceTest.java
+++ b/OurMemory_Server/src/test/java/com/kds/ourmemory/v1/service/room/RoomServiceTest.java
@@ -781,7 +781,7 @@ class RoomServiceTest {
                 RoomNotFoundException.class, () -> roomService.find(privateRoomId)
         );
 
-        var afterFindMemoriesList = memoryService.findMemories(insertOwnerRsp.getUserId(), null);
+        var afterFindMemoriesList = memoryService.findMemories(insertOwnerRsp.getUserId(), null, null, null);
         assertTrue(afterFindMemoriesList.isEmpty());
 
         var memoryOwner = insertMemoryRspOwner.getMemoryId();

--- a/OurMemory_Server/src/test/java/com/kds/ourmemory/v1/service/user/UserServiceTest.java
+++ b/OurMemory_Server/src/test/java/com/kds/ourmemory/v1/service/user/UserServiceTest.java
@@ -663,7 +663,7 @@ class UserServiceTest {
                 MemoryNotFoundException.class, () -> memoryService.find(privateMemoryId, privateMemoryRoomId)
         );
 
-        var findPrivateMemories = memoryService.findMemories(insertUserRsp.getUserId(), null);
+        var findPrivateMemories = memoryService.findMemories(insertUserRsp.getUserId(), null, null, null);
         assertThat(findPrivateMemories).isNotNull();
         assertThat(findPrivateMemories.isEmpty()).isTrue();
 
@@ -674,7 +674,7 @@ class UserServiceTest {
                 MemoryNotFoundException.class, () -> memoryService.find(privateRoomMemoryId, privateRoomRoomId)
         );
 
-        var findPrivateRoomMemories = memoryService.findMemories(insertUserRsp.getUserId(), null);
+        var findPrivateRoomMemories = memoryService.findMemories(insertUserRsp.getUserId(), null, null, null);
         assertThat(findPrivateRoomMemories).isNotNull();
         assertThat(findPrivateRoomMemories.isEmpty()).isTrue();
     }
@@ -781,11 +781,11 @@ class UserServiceTest {
                 MemoryNotFoundException.class, () -> memoryService.find(ownerRoomMemoryId, ownerRoomRoomId)
         );
 
-        var findMemoriesByUser = memoryService.findMemories(insertUserRsp.getUserId(), null);
+        var findMemoriesByUser = memoryService.findMemories(insertUserRsp.getUserId(), null, null, null);
         assertThat(findMemoriesByUser).isNotNull();
         assertTrue(findMemoriesByUser.isEmpty());
 
-        var findMemoriesByMember = memoryService.findMemories(insertMemberRsp.getUserId(), null);
+        var findMemoriesByMember = memoryService.findMemories(insertMemberRsp.getUserId(), null, null, null);
         assertThat(findMemoriesByMember).isNotNull();
         assertTrue(findMemoriesByMember.isEmpty());
     }
@@ -906,11 +906,11 @@ class UserServiceTest {
                 MemoryNotFoundException.class, () -> memoryService.find(participantRoomMemoryId, participantRoomRoomId)
         );
 
-        var findMemoriesByUser = memoryService.findMemories(insertUserRsp.getUserId(), null);
+        var findMemoriesByUser = memoryService.findMemories(insertUserRsp.getUserId(), null, null, null);
         assertThat(findMemoriesByUser).isNotNull();
         assertTrue(findMemoriesByUser.isEmpty());
 
-        var findMemoriesByMember = memoryService.findMemories(insertMemberRsp.getUserId(), null);
+        var findMemoriesByMember = memoryService.findMemories(insertMemberRsp.getUserId(), null, null, null);
         assertThat(findMemoriesByMember).isNotNull();
         assertTrue(findMemoriesByMember.isEmpty());
     }


### PR DESCRIPTION
## #209 

## PR 설명
- 일정 목록 조회 API 월 검색 조건 추가

## 변경된 내용
- 시작월 ~ 종료월 검색조건 추가
- 조건 없는 경우, 전체 검색
  + null ~ 종료월 : 종료월까지 모든 일정 검색
  + 시작월 ~ null : 시작월부터 모든 일정 검색
  + null ~ null : 모든 일정 검색

- 월 검색 테스트 코드 추가

## 추가적인 정보
- 버전관리 시작 => `[메이저].[마이너].[이슈]`