### PR TITLE
Feature/#198 github action deploy - 22.03.28_1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,9 +40,6 @@ jobs:
           cat << EOF >> fcmServiceKey.json
           ${{ secrets.FCM_SERVICE_KEY }}
 
-      - name: Echo application-test.yml
-        run: echo ${{ secrets.APPLICATION_TEST }}
-
       - name: Create application-test.yml
         run: |
           cd OurMemory_Server/src/main/resources
@@ -51,7 +48,8 @@ jobs:
           ${{ secrets.APPLICATION_TEST }}
 
       - name: Grant execute permission for gradlew
-        run: chmod +x ./OurMemory_Server/gradlew
+        run: chmod +x gradlew
+        working-directory: ./OurMemory_Server
 
       - name: Build with gradle
         run: ./gradlew build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,10 +39,12 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Grant execute permission for gradlew
-        run: chmod +x ./OurMemory_Server/gradlew
+        run: chmod +x gradlew
+        working-directory: ./OurMemory_Server
 
       - name: bootJar with Gradle
-        run: cd ./OurMemory_Server && ./gradlew bootJar
+        run: ./gradlew bootJar
+        working-directory: ./OurMemory_Server
 
       - name: copy OurMemory.jar, appspec.yml, scripts/
         run: cp -r ./OurMemory_Server/src/main/resources/codeDeploy/* . && cp ./OurMemory_Server/build/libs/OurMemory.jar .

--- a/OurMemory_Server/src/main/java/com/kds/ourmemory/v1/config/Swagger2Config.java
+++ b/OurMemory_Server/src/main/java/com/kds/ourmemory/v1/config/Swagger2Config.java
@@ -25,7 +25,7 @@ public class Swagger2Config implements WebMvcConfigurer{
 	private ApiInfo apiInfo() {
 		return new ApiInfoBuilder()
 				.title("기억공유 앱 서비스 - 서버")
-				.version("0.0.2") // Major.Minor.Issue
+				.version("0.0.3") // Major.Minor.Issue
 				.description("기억 공유 앱 서비스 API 서버")
 				.build();
 	}


### PR DESCRIPTION
## #198

## PR 설명
- GitHub Action 을 이용한 CI/CD 구현

## 변경된 내용
- 이슈 브랜치 푸시 및 풀리퀘스트할 경우 빌드 테스트하도록 수정
- develop 브랜치에 병합 후 deploy 전 빌드 테스트하도록 수정

## 추가적인 정보
- 포크된 레포지토리에서 작업한 뒤 풀리퀘스트를 통해 GitHub Action 실행하는 경우, 기준점이 포크된 레포지토리이기 때문에 해당 레포지토리의 시크릿을 사용하게 된다.
- 이 경우, 보안 상의 이슈로 `GITHUB_TOKEN` 을 제외하고 가져올 수 없기 때문에, 빌드 및 배포 과정이 실패하게 된다.
- 이를 해결하기 위해 이후 이슈 작업부터 포크된 레포지토리가 아닌 조직 레포지토리(KDS-OurMemory/Server) 에서 작업하도록 한다.